### PR TITLE
Add feature to set credential as environment variables

### DIFF
--- a/docs/eaa-provider-configuration.md
+++ b/docs/eaa-provider-configuration.md
@@ -41,5 +41,9 @@ provider "eaa" {
 #### Provider settings
 * ```contractid``` - (Required) The Akamai contract identifier for your Enterprise Application Access product.
 * ```accountswitchkey``` - (Optional) Runs the operation from another account.
-* ```edgerc``` - (Required) EAA TF plugin uses OpenAPI to configure the applications. API Client needs to be created from Akamai Enterprise Center, which contains client_secret, access_token & client_token required to authenticate Akamai EAA API. This setting contains the location of the .edgerc file. Follow the link for instructions on how to create [authentication credentials](https://techdocs.akamai.com/developer/docs/set-up-authentication-credentials
+* ```edgerc``` - (Optional) EAA TF plugin uses OpenAPI to configure the applications. API Client needs to be created from Akamai Enterprise Center, which contains client_secret, access_token & client_token required to authenticate Akamai EAA API. This setting contains the location of the .edgerc file. Follow the link for instructions on how to create [authentication credentials](https://techdocs.akamai.com/developer/docs/set-up-authentication-credentials
 )
+
+#### Environment variables
+The authentication credentials can also be set using environment variables. The environment variables are:
+https://techdocs.akamai.com/terraform/docs/environment-variables

--- a/pkg/eaaprovider/provider.go
+++ b/pkg/eaaprovider/provider.go
@@ -34,7 +34,7 @@ func Provider() *schema.Provider {
 			},
 			"edgerc": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "The edgerc file path key for the provider.",
 			},
 		},
@@ -57,7 +57,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	edgercPath := d.Get("edgerc").(string)
 
-	edgerc, err := edgegrid.New(edgegrid.WithFile(edgercPath))
+	edgerc, err := edgegrid.New(edgegrid.WithEnv(true), edgegrid.WithFile(edgercPath))
 	if err != nil {
 		return nil, diag.Errorf("%s: %s", ErrInvalidEdgercConfig, err.Error())
 	}


### PR DESCRIPTION
The EdgeGrid library had an option to set credentials from environment variables, so I used that to fix it.

Now we can use both the .edgerc file or environment variables for credentials.

Due to EdgeGrid's library specs, if both are set, the environment variable takes precedence.