### PR TITLE
BWVONE-48401: remove aws_classic

### DIFF
--- a/docs/connector-pool.md
+++ b/docs/connector-pool.md
@@ -21,7 +21,6 @@ This resource supports the following arguments:
   * `kvm` - KVM package type
   * `hyperv` - Hyper-V package type
   * `docker` - Docker package type
-  * `aws_classic` - AWS Classic package type
   * `azure` - Azure package type
   * `google` - Google Cloud package type
   * `softlayer` - SoftLayer package type

--- a/docs/create-connector.md
+++ b/docs/create-connector.md
@@ -13,7 +13,7 @@ See [examples/connectors.tf](../examples/connectors.tf) for a complete working e
 - `name` (Required): Connector name.
 - `description` (Optional): Free-text description.
 - `debug_channel_permitted` (Optional): Enable debug channel for support.
-- `package` (Required): Installer package flavor, e.g. `aws_classic`, `vmware`, etc.
+- `package` (Required): Installer package flavor, e.g. `aws`, `vmware`, etc.
 - `advanced_settings.network_info` (Optional): List of CIDRs/IPs used during install/registration.
 
 

--- a/examples/connectors.tf
+++ b/examples/connectors.tf
@@ -18,7 +18,7 @@ resource "eaa_connector" "sample_connector" {
   name                    = "sample_connector"
   description             = "created using terraform"
   debug_channel_permitted = true
-  package                 = "aws_classic"
+  package                 = "aws"
   advanced_settings {
     network_info = ["0.0.0.0"]
   }

--- a/pkg/client/constants.go
+++ b/pkg/client/constants.go
@@ -621,7 +621,6 @@ const (
 	ConnPackageTypeKVM        ConnPackageType = "kvm"
 	ConnPackageTypeHyperv     ConnPackageType = "hyperv"
 	ConnPackageTypeDocker     ConnPackageType = "docker"
-	ConnPackageTypeAWSClassic ConnPackageType = "aws_classic"
 	ConnPackageTypeAzure      ConnPackageType = "azure"
 	ConnPackageTypeGoogle     ConnPackageType = "google"
 	ConnPackageTypeSoftLayer  ConnPackageType = "softlayer"
@@ -642,8 +641,6 @@ func (cat ConnPackageType) ToInt() (int, error) {
 		return int(AGENT_PACKAGE_HYPERV), nil
 	case ConnPackageTypeDocker:
 		return int(AGENT_PACKAGE_DOCKER), nil
-	case ConnPackageTypeAWSClassic:
-		return int(AGENT_PACKAGE_AWS_CLASSIC), nil
 	case ConnPackageTypeAzure:
 		return int(AGENT_PACKAGE_AZURE), nil
 	case ConnPackageTypeGoogle:
@@ -666,7 +663,6 @@ const (
 	AGENT_PACKAGE_KVM
 	AGENT_PACKAGE_HYPERV
 	AGENT_PACKAGE_DOCKER
-	AGENT_PACKAGE_AWS_CLASSIC
 	AGENT_PACKAGE_AZURE
 	AGENT_PACKAGE_GOOGLE
 	AGENT_PACKAGE_SOFTLAYER
@@ -687,8 +683,6 @@ func (cat ConnPackageTypeInt) String() (string, error) {
 		return string(ConnPackageTypeHyperv), nil
 	case AGENT_PACKAGE_DOCKER:
 		return string(ConnPackageTypeDocker), nil
-	case AGENT_PACKAGE_AWS_CLASSIC:
-		return string(ConnPackageTypeAWSClassic), nil
 	case AGENT_PACKAGE_AZURE:
 		return string(ConnPackageTypeAzure), nil
 	case AGENT_PACKAGE_GOOGLE:

--- a/pkg/eaaprovider/data_source_connector_pools.go
+++ b/pkg/eaaprovider/data_source_connector_pools.go
@@ -349,7 +349,7 @@ func dataSourceEaaConnectorPools() *schema.Resource {
 						"package_type": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "Package type for the connector pool (vmware, vbox, aws, kvm, hyperv, docker, aws_classic, azure, google, softlayer, fujitsu_k5)",
+							Description: "Package type for the connector pool (vmware, vbox, aws, kvm, hyperv, docker, azure, google, softlayer, fujitsu_k5)",
 						},
 						"infra_type": {
 							Type:        schema.TypeString,

--- a/pkg/eaaprovider/resource_eaa_connector_pool.go
+++ b/pkg/eaaprovider/resource_eaa_connector_pool.go
@@ -33,7 +33,6 @@ func validatePackageType(val interface{}, key string) (warns []string, errs []er
 		string(client.ConnPackageTypeKVM),
 		string(client.ConnPackageTypeHyperv),
 		string(client.ConnPackageTypeDocker),
-		string(client.ConnPackageTypeAWSClassic),
 		string(client.ConnPackageTypeAzure),
 		string(client.ConnPackageTypeGoogle),
 		string(client.ConnPackageTypeSoftLayer),
@@ -120,7 +119,7 @@ func resourceEaaConnectorPool() *schema.Resource {
 			"package_type": {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "Package type for the connector pool. Valid values: vmware, vbox, aws, kvm, hyperv, docker, aws_classic, azure, google, softlayer, fujitsu_k5",
+				Description:  "Package type for the connector pool. Valid values: vmware, vbox, aws, kvm, hyperv, docker, azure, google, softlayer, fujitsu_k5",
 				ValidateFunc: validatePackageType,
 			},
 			"description": {

--- a/pkg/eaaprovider/resource_eaa_connector_pool_test.go
+++ b/pkg/eaaprovider/resource_eaa_connector_pool_test.go
@@ -637,11 +637,6 @@ func TestValidatePackageTypeEdgeCases(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:          "valid_aws_classic",
-			value:         "aws_classic",
-			expectedError: false,
-		},
-		{
 			name:          "valid_softlayer",
 			value:         "softlayer",
 			expectedError: false,


### PR DESCRIPTION
- BWVONE-48401: remove legacy aws_classic package type for connectors, since UI has dropped support and doesn't handle properly.