### PR TITLE
BWVONE-48401: deprecate aws_classic package_type

### DIFF
--- a/docs/connector-pool.md
+++ b/docs/connector-pool.md
@@ -21,7 +21,6 @@ This resource supports the following arguments:
   * `kvm` - KVM package type
   * `hyperv` - Hyper-V package type
   * `docker` - Docker package type
-  * `aws_classic` - AWS Classic package type
   * `azure` - Azure package type
   * `google` - Google Cloud package type
   * `softlayer` - SoftLayer package type

--- a/docs/create-connector.md
+++ b/docs/create-connector.md
@@ -13,7 +13,7 @@ See [examples/connectors.tf](../examples/connectors.tf) for a complete working e
 - `name` (Required): Connector name.
 - `description` (Optional): Free-text description.
 - `debug_channel_permitted` (Optional): Enable debug channel for support.
-- `package` (Required): Installer package flavor, e.g. `aws_classic`, `vmware`, etc.
+- `package` (Required): Installer package flavor, e.g. `aws`, `vmware`, etc.
 - `advanced_settings.network_info` (Optional): List of CIDRs/IPs used during install/registration.
 
 

--- a/examples/connectors.tf
+++ b/examples/connectors.tf
@@ -18,7 +18,7 @@ resource "eaa_connector" "sample_connector" {
   name                    = "sample_connector"
   description             = "created using terraform"
   debug_channel_permitted = true
-  package                 = "aws_classic"
+  package                 = "aws"
   advanced_settings {
     network_info = ["0.0.0.0"]
   }

--- a/pkg/eaaprovider/data_source_connector_pools.go
+++ b/pkg/eaaprovider/data_source_connector_pools.go
@@ -349,7 +349,7 @@ func dataSourceEaaConnectorPools() *schema.Resource {
 						"package_type": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "Package type for the connector pool (vmware, vbox, aws, kvm, hyperv, docker, aws_classic, azure, google, softlayer, fujitsu_k5)",
+							Description: "Package type for the connector pool (vmware, vbox, aws, kvm, hyperv, docker, azure, google, softlayer, fujitsu_k5)",
 						},
 						"infra_type": {
 							Type:        schema.TypeString,

--- a/pkg/eaaprovider/resource_eaa_connector.go
+++ b/pkg/eaaprovider/resource_eaa_connector.go
@@ -41,8 +41,10 @@ func resourceEaaConnector() *schema.Resource {
 				Optional: true,
 			},
 			"package": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "Package type for the connector. Valid values: vmware, vbox, aws, kvm, hyperv, docker, azure, google, softlayer, fujitsu_k5. Note: aws_classic is no longer supported for new resources; use aws instead.",
+				ValidateFunc: validatePackageType,
 			},
 			"reach": {
 				Type:        schema.TypeInt,
@@ -118,6 +120,12 @@ func resourceEaaConnector() *schema.Resource {
 // resourceEaaConnectorCreate function is responsible for creating a new EAA Connector.
 // constructs the connector creation request using data from the schema and creates the connector.
 func resourceEaaConnectorCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if v, ok := d.GetOk("package"); ok {
+		if pkgType, isStr := v.(string); isStr && pkgType == string(client.ConnPackageTypeAWSClassic) {
+			return diag.Errorf("\"aws_classic\" is no longer supported for new connectors, please use \"aws\" instead")
+		}
+	}
+
 	eaaclient, err := Client(m)
 	if err != nil {
 		return diag.FromErr(err)
@@ -179,14 +187,14 @@ func resourceEaaConnectorRead(ctx context.Context, d *schema.ResourceData, m int
 	connPackage := client.ConnPackageTypeInt(connResp.Package)
 	connPackageString, err := connPackage.String()
 	if err != nil {
-		eaaclient.Logger.Info("error converting package")
+		eaaclient.Logger.Warn("error converting package type", "raw_value", connResp.Package, "error", err)
 	}
 	attrs["package"] = connPackageString
 
 	connState := client.ConnPackageStateInt(connResp.State)
 	connStateString, err := connState.String()
 	if err != nil {
-		eaaclient.Logger.Info("error converting connector state")
+		eaaclient.Logger.Warn("error converting connector state", "raw_value", connResp.State, "error", err)
 	}
 	attrs["state"] = connStateString
 
@@ -198,6 +206,14 @@ func resourceEaaConnectorRead(ctx context.Context, d *schema.ResourceData, m int
 
 // resourceEaaConnectorUpdate approves the connector if it is ready to be approved
 func resourceEaaConnectorUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if d.HasChange("package") {
+		if v, ok := d.GetOk("package"); ok {
+			if pkgType, isStr := v.(string); isStr && pkgType == string(client.ConnPackageTypeAWSClassic) {
+				return diag.Errorf("\"aws_classic\" is no longer supported, please use \"aws\" instead")
+			}
+		}
+	}
+
 	// Set the resource ID
 	id := d.Id()
 	eaaclient, err := Client(m)
@@ -236,7 +252,9 @@ func resourceEaaConnectorUpdate(ctx context.Context, d *schema.ResourceData, m i
 			return diag.FromErr(err)
 		}
 		if getResp.StatusCode < http.StatusOK || getResp.StatusCode >= http.StatusMultipleChoices {
-			logger.Error("approve connector failed", "error", err)
+			desc := client.FormatErrorDescription(getResp)
+			logger.Error("approve connector failed", "status_code", getResp.StatusCode, "error", desc)
+			return diag.Errorf("approve connector failed: %s", desc)
 		}
 	}
 

--- a/pkg/eaaprovider/resource_eaa_connector_pool.go
+++ b/pkg/eaaprovider/resource_eaa_connector_pool.go
@@ -120,7 +120,7 @@ func resourceEaaConnectorPool() *schema.Resource {
 			"package_type": {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "Package type for the connector pool. Valid values: vmware, vbox, aws, kvm, hyperv, docker, aws_classic, azure, google, softlayer, fujitsu_k5",
+				Description:  "Package type for the connector pool. Valid values: vmware, vbox, aws, kvm, hyperv, docker, azure, google, softlayer, fujitsu_k5. Note: aws_classic is no longer supported for new resources; use aws instead.",
 				ValidateFunc: validatePackageType,
 			},
 			"description": {
@@ -284,6 +284,12 @@ func resourceEaaConnectorPool() *schema.Resource {
 
 // resourceEaaConnectorPoolCreate function is responsible for creating a new EAA Connector Pool.
 func resourceEaaConnectorPoolCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if v, ok := d.GetOk("package_type"); ok {
+		if pkgType, isStr := v.(string); isStr && pkgType == string(client.ConnPackageTypeAWSClassic) {
+			return diag.Errorf("\"aws_classic\" is no longer supported for new connector pools, please use \"aws\" instead")
+		}
+	}
+
 	e := hasDuplicateTokenNames(d)
 	if e != nil {
 		return diag.FromErr(e)
@@ -447,6 +453,14 @@ func resourceEaaConnectorPoolRead(ctx context.Context, d *schema.ResourceData, m
 
 // resourceEaaConnectorPoolUpdate updates an existing EAA connector pool.
 func resourceEaaConnectorPoolUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if d.HasChange("package_type") {
+		if v, ok := d.GetOk("package_type"); ok {
+			if pkgType, isStr := v.(string); isStr && pkgType == string(client.ConnPackageTypeAWSClassic) {
+				return diag.Errorf("\"aws_classic\" is no longer supported, please use \"aws\" instead")
+			}
+		}
+	}
+
 	e := hasDuplicateTokenNames(d)
 	if e != nil {
 		return diag.FromErr(e)

--- a/pkg/eaaprovider/resource_eaa_connector_pool_test.go
+++ b/pkg/eaaprovider/resource_eaa_connector_pool_test.go
@@ -37,6 +37,11 @@ func TestValidatePackageType(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name:          "valid_aws_classic",
+			value:         "aws_classic",
+			expectedError: false,
+		},
+		{
 			name:          "valid_docker",
 			value:         "docker",
 			expectedError: false,
@@ -54,6 +59,11 @@ func TestValidatePackageType(t *testing.T) {
 		{
 			name:          "invalid_type",
 			value:         "invalid",
+			expectedError: true,
+		},
+		{
+			name:          "invalid_aws_classic_casing",
+			value:         "AWS_Classic",
 			expectedError: true,
 		},
 		{
@@ -77,7 +87,6 @@ func TestValidatePackageType(t *testing.T) {
 				}
 			}
 
-			// Warnings should be empty for this validator
 			if len(warns) > 0 {
 				t.Errorf("Unexpected warnings for test case %s: %v", tt.name, warns)
 			}
@@ -637,6 +646,11 @@ func TestValidatePackageTypeEdgeCases(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name:          "valid_aws",
+			value:         "aws",
+			expectedError: false,
+		},
+		{
 			name:          "valid_aws_classic",
 			value:         "aws_classic",
 			expectedError: false,
@@ -672,7 +686,6 @@ func TestValidatePackageTypeEdgeCases(t *testing.T) {
 				}
 			}
 
-			// Warnings should be empty for this validator
 			if len(warns) > 0 {
 				t.Errorf("Unexpected warnings for test case %s: %v", tt.name, warns)
 			}


### PR DESCRIPTION
- BWVONE-48401: deprecate aws_classic package_type for connector and connector_pools