### PR TITLE
BWVONE-49241: move tls_suite_name to top-level attribute, remove tls_suite_type and generate_self_signed_cert

### DIFF
--- a/docs/eaa_application.md
+++ b/docs/eaa_application.md
@@ -12,14 +12,15 @@ Manages the lifecycle of an EAA application.
 * `domain` - (Optional) Domain type. Values: `custom`, `wapp`. Default `wapp`.
 * `host` - (Optional) External hostname for the application.
 * `bookmark_url` - (Optional) URL for bookmark applications.
-* `pop` - (Optional/Computed) PoP identifier.
-* `popname` - (Optional/Computed) PoP name.
+* `pop` - (Computed) PoP identifier.
+* `popname` - (Computed) PoP name.
 * `popregion` - (Optional/Computed) Target region for deployment.
 * `app_category` - (Optional) Application category name.
 * `agents` - (Optional) List of connector names to assign.
 * `auth_enabled` - (Optional) Enable application authentication. Default `"false"` (string; use `"true"`/`"false"`).
 * `protocol` - (Optional, SaaS only) Auth protocol. Values: `SAML`, `SAML2.0`, `OIDC`, `OpenID Connect 1.0`, `WSFed`, `WS-Federation`. Note: lowercase `wsfed` is NOT valid.
 * `app_bundle` - (Optional) Application bundle name for grouping related apps.
+* `tls_suite_name` - (Optional/Computed) TLS cipher suite name. See [TLS Suite](#tls-suite) for details.
 
 ### Servers
 
@@ -38,10 +39,12 @@ Manages the lifecycle of an EAA application.
 
 ### Certificates
 
-* `cert_name` - (Optional) Certificate name for custom domain.
-* `cert_type` - (Optional) Certificate type.
-* `cert` - (Optional/Computed) Certificate content.
-* `generate_self_signed_cert` - (Optional) Generate a self-signed certificate.
+* `cert_type` - (Optional) Certificate type for custom domain. Valid values: `self_signed` (default), `uploaded`.
+  * **`self_signed`** — The provider checks if a self-signed certificate already exists for the application's `host`. If one exists, it is reused. Otherwise, a new self-signed certificate is automatically generated. No additional fields are required.
+  * **`uploaded`** — The provider looks up a previously uploaded certificate by the name specified in `cert_name`. The certificate must already exist in EAA; if it is not found, the operation fails.
+* `cert_name` - (Optional) Name of a previously uploaded certificate to use. Required when `cert_type` is `uploaded`. Ignored when `cert_type` is `self_signed`.
+* `cert` - (Computed) The resolved certificate UUID assigned to the application. This is set automatically by the provider based on `cert_type` and `cert_name`.
+* `cert_body` - (Computed, Sensitive) The certificate body content. Set automatically by the provider.
 
 ### Authentication
 
@@ -72,6 +75,15 @@ Manages the lifecycle of an EAA application.
       * `operator` - (Required) Operator.
       * `type` - (Required) Condition type.
       * `value` - (Required) Condition value.
+
+### TLS Suite
+
+* `tls_suite_name` - (Optional/Computed, top-level) TLS cipher suite name for the application. When omitted, the API assigns the partner default suite. Use the `eaa_data_source_tls_cipher_suites` data source to discover valid suite names for an application.
+
+  **Behavior notes:**
+  - The API does not validate the suite name — an incorrect name will be saved without error.
+  - Setting `tls_suite_name = ""` (empty string) has no effect — the API does not support clearing the suite name. The provider silently ignores the empty value and the previously assigned suite remains active.
+  - Once set, removing `tls_suite_name` from the config will not reset it to the default. The previously computed value remains in Terraform state. To change the suite, set it to a different valid name explicitly.
 
 ## Computed Attributes
 
@@ -155,11 +167,6 @@ The `advanced_settings` map also accepts keys not listed here — any key the EA
 * `cors_support_credential` - Support credentials.
 * `cors_max_age` - Preflight cache duration in seconds.
 
-### TLS Suite
-
-* `tls_suite_type` - TLS suite type: `default` or `custom`.
-* `tls_suite_name` - TLS suite name (when `tls_suite_type = "custom"`).
-
 ### SSL & WebSocket
 
 * `is_ssl_verification_enabled` - SSL cert verification. Default `true`.
@@ -225,12 +232,12 @@ Which advanced settings categories are allowed per app type:
 | Enterprise Connectivity | ✓ | ✓ | ✓ | limited | - | - |
 | Authentication | ✓ (all methods) | ✓ (all methods) | ✓ (no `app_auth`) | blocked | - | - |
 | CORS | ✓ | - | - | blocked | - | - |
-| TLS Suite | ✓ | ✓ | ✓ | blocked | - | - |
 | SSL & WebSocket | ✓ | ✓ | ✓ | ✓ (required) | - | - |
 | Tunnel Client | - | - | - | ✓ (required) | - | - |
 | Security | ✓ | ✓ | ✓ | ✓ | - | - |
 | RDP | - | ✓ | - | - | - | - |
 | Miscellaneous | ✓ | ✓ | ✓ | limited | - | - |
+
 
 **Bookmark and SaaS apps do not support `advanced_settings` at all.**
 
@@ -326,8 +333,6 @@ resource "eaa_application" "custom_domain_app" {
   host        = "app.example.com"
   popregion   = "us-east-1"
   agents      = ["my-connector"]
-
-  generate_self_signed_cert = true
 
   servers {
     origin_host     = "internal-app.corp.example.com"

--- a/pkg/client/app_advanced_settings.go
+++ b/pkg/client/app_advanced_settings.go
@@ -215,11 +215,6 @@ func advancedSettingsFromBlock(block map[string]interface{}) (*AdvancedSettings,
 	// Remove from flat map so applyAdvancedSettingsWithReflection doesn't try to handle the string.
 	delete(flat, "rdp_remote_apps")
 
-	// tls_suite_type / tls_suite_name are handled at the call site (CREATE/UPDATE flows),
-	// not inside AdvancedSettings struct. Remove them so reflection doesn't try to find them.
-	delete(flat, "tls_suite_type")
-	delete(flat, "tls_suite_name")
-
 	// Marshal to JSON and reuse ParseAdvancedSettingsWithDefaults so all defaults are applied.
 	jsonBytes, err := json.Marshal(flat)
 	if err != nil {
@@ -373,8 +368,6 @@ func applyAdvancedSettingsWithReflection(advSettings *AdvancedSettings, userSett
 		"single_host_path":               "SingleHostPath",
 		"user_name":                      "UserName",
 		"wildcard_internal_hostname":     "WildcardInternalHostname",
-		"tlsSuiteType":                   "TLSSuiteType",
-		"tls_suite_name":                 "TLSSuiteName",
 
 		// JWT fields
 		"jwt_audience":      "JWTAudience",

--- a/pkg/client/app_advanced_settings_test.go
+++ b/pkg/client/app_advanced_settings_test.go
@@ -283,25 +283,6 @@ func TestAdvancedSettingsFromBlock_RequestParameters(t *testing.T) {
 	assert.Equal(t, `{"key":"value"}`, *got.RequestParameters)
 }
 
-func TestAdvancedSettingsFromBlock_StripsTLSKeys(t *testing.T) {
-	block := map[string]interface{}{
-		"tls_suite_type": "1",
-		"tls_suite_name": "tls-1-2",
-		"acceleration":   "true",
-	}
-	got, err := advancedSettingsFromBlock(block)
-	require.NoError(t, err)
-
-	// TLS keys should NOT appear in ExtraFields
-	if got.ExtraFields != nil {
-		_, hasTLSType := got.ExtraFields["tls_suite_type"]
-		_, hasTLSName := got.ExtraFields["tls_suite_name"]
-		assert.False(t, hasTLSType, "tls_suite_type should not appear in ExtraFields")
-		assert.False(t, hasTLSName, "tls_suite_name should not appear in ExtraFields")
-	}
-	assert.Equal(t, "true", got.Acceleration)
-}
-
 func TestAdvancedSettingsFromBlock_InvalidHealthCheckType(t *testing.T) {
 	block := map[string]interface{}{
 		"health_check_type": "99",

--- a/pkg/client/application.go
+++ b/pkg/client/application.go
@@ -24,7 +24,6 @@ type MinimalCreateAppRequest struct {
 type CreateAppRequest struct {
 	Description      *string          `json:"description"`
 	TLSSuiteName     *string          `json:"tls_suite_name,omitempty"`
-	TLSSuiteType     *int             `json:"tlsSuiteType,omitempty"`
 	OIDCSettings     *OIDCConfig      `json:"oidc_settings"`
 	AdvancedSettings AdvancedSettings `json:"advanced_settings,omitempty"`
 	Name             string           `json:"name"`
@@ -259,31 +258,16 @@ func (car *CreateAppRequest) CreateAppRequestFromSchema(ctx context.Context, d *
 		return fmt.Errorf("failed to parse advanced settings block: %w", err)
 	}
 
-	// Extract TLS Suite fields from the structured block
-	logging.Debug(ctx, "CREATE FLOW: TLS Suite extraction from block", tags)
-	if tlsSuiteTypeStr, ok := userSettings["tls_suite_type"].(string); ok && tlsSuiteTypeStr != "" {
-		logging.Debug(ctx, "CREATE FLOW: found tls_suite_type", tags, map[string]any{"value": tlsSuiteTypeStr})
-		var tlsSuiteTypeInt int
-		switch tlsSuiteTypeStr {
-		case "default":
-			tlsSuiteTypeInt = 1
-		case "custom":
-			tlsSuiteTypeInt = 2
-		default:
-			logging.Error(ctx, "CREATE FLOW: invalid tls_suite_type", tags, map[string]any{"value": tlsSuiteTypeStr})
-			return fmt.Errorf("invalid tls_suite_type value: %s", tlsSuiteTypeStr)
+	// tls_suite_name is read from the top-level Terraform schema attribute (not from the advanced_settings map)
+	if tlsSuiteName, ok := d.GetOk("tls_suite_name"); ok {
+		if tlsSuiteNameStr, ok := tlsSuiteName.(string); ok {
+			if tlsSuiteNameStr != "" {
+				car.TLSSuiteName = &tlsSuiteNameStr
+				logging.Debug(ctx, "CREATE FLOW: tls_suite_name set", tags, map[string]any{"value": tlsSuiteNameStr})
+			} else {
+				logging.Warn(ctx, "CREATE FLOW: tls_suite_name is set to empty string; ignoring because the API does not support clearing", tags)
+			}
 		}
-		car.TLSSuiteType = &tlsSuiteTypeInt
-		logging.Debug(ctx, "CREATE FLOW: TLSSuiteType set", tags, map[string]any{"value": tlsSuiteTypeInt})
-	} else {
-		logging.Debug(ctx, "CREATE FLOW: tls_suite_type not set in block", tags)
-	}
-
-	if tlsSuiteNameStr, ok := userSettings["tls_suite_name"].(string); ok && tlsSuiteNameStr != "" {
-		logging.Debug(ctx, "CREATE FLOW: tls_suite_name set", tags, map[string]any{"value": tlsSuiteNameStr})
-		car.TLSSuiteName = &tlsSuiteNameStr
-	} else {
-		logging.Debug(ctx, "CREATE FLOW: tls_suite_name not set in block", tags)
 	}
 
 	// Set authentication flags based on Terraform boolean flags for CREATE flow
@@ -640,11 +624,11 @@ func ConfigureAuthentication(ctx context.Context, appID string, d *schema.Resour
 				appAuthenticationMap, ok := appAuthList[0].(map[string]interface{})
 				if !ok {
 					logging.Error(ctx, "invalid authentication data", tags)
-					return ErrInvalidType
+					return fmt.Errorf("invalid app_authentication: unexpected type, expected map[string]interface{}")
 				}
 				if appAuthenticationMap == nil {
-					logging.Error(ctx, "invalid authentication data", tags)
-					return ErrInvalidValue
+					logging.Error(ctx, "empty authentication data", tags)
+					return fmt.Errorf("invalid app_authentication data")
 				}
 
 				// Check if app_idp key is present
@@ -814,7 +798,6 @@ type Application struct {
 	OIDCSettings           *OIDCConfig          `json:"oidc_settings,omitempty"`
 	CName                  *string              `json:"cname"`
 	Host                   *string              `json:"host"`
-	TLSSuiteType           *int                 `json:"tlsSuiteType,omitempty"`
 	AppLogo                *string              `json:"app_logo"`
 	TLSSuiteName           *string              `json:"tls_suite_name"`
 	OriginHost             *string              `json:"origin_host"`
@@ -1084,6 +1067,18 @@ func (appUpdateReq *ApplicationUpdateRequest) UpdateAppRequestFromSchema(ctx con
 		}
 	}
 
+	// tls_suite_name is read from the top-level Terraform schema attribute (not from the advanced_settings map)
+	if tlsSuiteName, ok := d.GetOk("tls_suite_name"); ok {
+		if tlsSuiteNameStr, ok := tlsSuiteName.(string); ok {
+			if tlsSuiteNameStr != "" {
+				appUpdateReq.TLSSuiteName = &tlsSuiteNameStr
+				logging.Debug(ctx, "UPDATE FLOW: tls_suite_name set", tags, map[string]any{"value": tlsSuiteNameStr})
+			} else {
+				logging.Warn(ctx, "UPDATE FLOW: tls_suite_name is set to empty string; ignoring because the API does not support clearing", tags)
+			}
+		}
+	}
+
 	// Handle advanced settings for UPDATE flow - read from TypeMap block
 	var updateUserSettings map[string]interface{}
 	if advMap, ok := d.GetOk("advanced_settings"); ok {
@@ -1101,32 +1096,6 @@ func (appUpdateReq *ApplicationUpdateRequest) UpdateAppRequestFromSchema(ctx con
 
 		// Preserve user-provided app_auth value from advanced_settings
 		logging.Debug(ctx, "UPDATE FLOW: using app_auth from advanced_settings", tags, map[string]any{"app_auth": advSettings.AppAuth})
-
-		// Extract TLS Suite fields from the structured block
-		logging.Debug(ctx, "UPDATE FLOW: TLS Suite extraction from block", tags)
-		if tlsSuiteTypeStr, ok := updateUserSettings["tls_suite_type"].(string); ok && tlsSuiteTypeStr != "" {
-			var tlsSuiteTypeInt int
-			switch tlsSuiteTypeStr {
-			case "default":
-				tlsSuiteTypeInt = 1
-			case "custom":
-				tlsSuiteTypeInt = 2
-			default:
-				logging.Error(ctx, "UPDATE FLOW: invalid tls_suite_type", tags, map[string]any{"value": tlsSuiteTypeStr})
-				return fmt.Errorf("invalid tls_suite_type value: %s", tlsSuiteTypeStr)
-			}
-			appUpdateReq.TLSSuiteType = &tlsSuiteTypeInt
-			logging.Debug(ctx, "UPDATE FLOW: TLSSuiteType set", tags, map[string]any{"value": tlsSuiteTypeInt})
-		} else {
-			logging.Debug(ctx, "UPDATE FLOW: tls_suite_type not set in block", tags)
-		}
-
-		if tlsSuiteNameStr, ok := updateUserSettings["tls_suite_name"].(string); ok && tlsSuiteNameStr != "" {
-			appUpdateReq.TLSSuiteName = &tlsSuiteNameStr
-			logging.Debug(ctx, "UPDATE FLOW: tls_suite_name set", tags, map[string]any{"value": tlsSuiteNameStr})
-		} else {
-			logging.Debug(ctx, "UPDATE FLOW: tls_suite_name not set in block", tags)
-		}
 
 		// Note: SAML/OIDC/WS-FED settings are now handled outside this block
 		// to ensure they run regardless of whether advanced_settings is provided
@@ -2000,7 +1969,6 @@ type AdvancedSettingsComplete struct {
 	IDPMaxExpiry                 *string                `json:"idp_max_expiry,omitempty"`
 	AppLocation                  *string                `json:"app_location"`
 	TLSSuiteName                 *string                `json:"tls_suite_name,omitempty"`
-	TLSSuiteType                 *int                   `json:"tlsSuiteType,omitempty"`
 	EdgeTransportPropertyID      *string                `json:"edge_transport_property_id,omitempty"`
 	G2OKey                       *string                `json:"g2o_key,omitempty"`
 	G2ONonce                     *string                `json:"g2o_nonce,omitempty"`

--- a/pkg/client/application_test.go
+++ b/pkg/client/application_test.go
@@ -947,22 +947,22 @@ func TestCreateAppRequestFromSchema_Direct(t *testing.T) {
 		"app_type":          {Type: schema.TypeString, Optional: true},
 		"app_profile":       {Type: schema.TypeString, Optional: true},
 		"client_app_mode":   {Type: schema.TypeString, Optional: true},
+		"tls_suite_name":    {Type: schema.TypeString, Optional: true},
 		"advanced_settings": {Type: schema.TypeMap, Optional: true},
 	}
 
 	ec := &EaaClient{}
 
-	t.Run("success_with_tls_suite_fields", func(t *testing.T) {
+	t.Run("success_with_tls_suite_name", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, createSchema, map[string]interface{}{
 			"name":            "create-app",
 			"description":     "desc",
 			"app_type":        "enterprise",
 			"app_profile":     "http",
 			"client_app_mode": "tcp",
+			"tls_suite_name":  "my-suite",
 			"advanced_settings": map[string]interface{}{
-				"app_auth":       "none",
-				"tls_suite_type": "custom",
-				"tls_suite_name": "my-suite",
+				"app_auth": "none",
 			},
 		})
 
@@ -972,10 +972,22 @@ func TestCreateAppRequestFromSchema_Direct(t *testing.T) {
 		require.Equal(t, "create-app", req.Name)
 		require.NotNil(t, req.Description)
 		assert.Equal(t, "desc", *req.Description)
-		require.NotNil(t, req.TLSSuiteType)
-		assert.Equal(t, 2, *req.TLSSuiteType)
 		require.NotNil(t, req.TLSSuiteName)
 		assert.Equal(t, "my-suite", *req.TLSSuiteName)
+	})
+
+	t.Run("empty_tls_suite_name_is_ignored", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, createSchema, map[string]interface{}{
+			"name":           "create-app",
+			"app_type":       "enterprise",
+			"app_profile":    "http",
+			"tls_suite_name": "",
+		})
+
+		req := &CreateAppRequest{}
+		err := req.CreateAppRequestFromSchema(context.Background(), d, ec)
+		requireErrIs(t, err, false, nil)
+		assert.Nil(t, req.TLSSuiteName, "empty tls_suite_name should not be sent to the API")
 	})
 
 	t.Run("missing_name_fails", func(t *testing.T) {
@@ -983,19 +995,6 @@ func TestCreateAppRequestFromSchema_Direct(t *testing.T) {
 		req := &CreateAppRequest{}
 		err := req.CreateAppRequestFromSchema(context.Background(), d, ec)
 		requireErrIs(t, err, true, ErrInvalidValue)
-	})
-
-	t.Run("invalid_tls_suite_type_fails", func(t *testing.T) {
-		d := schema.TestResourceDataRaw(t, createSchema, map[string]interface{}{
-			"name": "create-app",
-			"advanced_settings": map[string]interface{}{
-				"tls_suite_type": "invalid",
-			},
-		})
-		req := &CreateAppRequest{}
-		err := req.CreateAppRequestFromSchema(context.Background(), d, ec)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid tls_suite_type value")
 	})
 }
 
@@ -1014,6 +1013,7 @@ func TestUpdateAppRequestFromSchema_Direct(t *testing.T) {
 				"proto_type": {Type: schema.TypeInt, Optional: true},
 			}},
 		},
+		"tls_suite_name":    {Type: schema.TypeString, Optional: true},
 		"advanced_settings": {Type: schema.TypeMap, Optional: true},
 	}
 
@@ -1021,17 +1021,16 @@ func TestUpdateAppRequestFromSchema_Direct(t *testing.T) {
 
 	t.Run("success_maps_basic_and_tls_fields", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, updateSchema, map[string]interface{}{
-			"name":        "updated-app",
-			"description": "updated-desc",
-			"host":        "updated.example.com",
-			"domain":      "wapp",
+			"name":           "updated-app",
+			"description":    "updated-desc",
+			"host":           "updated.example.com",
+			"domain":         "wapp",
+			"tls_suite_name": "default-suite",
 			"tunnel_internal_hosts": []interface{}{
 				map[string]interface{}{"host": "10.0.0.2", "port_range": "22", "proto_type": 6},
 			},
 			"advanced_settings": map[string]interface{}{
-				"app_auth":       "none",
-				"tls_suite_type": "default",
-				"tls_suite_name": "default-suite",
+				"app_auth": "none",
 			},
 		})
 
@@ -1046,22 +1045,21 @@ func TestUpdateAppRequestFromSchema_Direct(t *testing.T) {
 		assert.Equal(t, "2", req.Domain)
 		require.Len(t, req.TunnelInternalHosts, 1)
 		assert.Equal(t, "10.0.0.2", req.TunnelInternalHosts[0].Host)
-		require.NotNil(t, req.TLSSuiteType)
-		assert.Equal(t, 1, *req.TLSSuiteType)
 		require.NotNil(t, req.TLSSuiteName)
 		assert.Equal(t, "default-suite", *req.TLSSuiteName)
 	})
 
-	t.Run("invalid_tls_suite_type_fails", func(t *testing.T) {
+	t.Run("empty_tls_suite_name_is_ignored", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, updateSchema, map[string]interface{}{
-			"advanced_settings": map[string]interface{}{
-				"tls_suite_type": "invalid",
-			},
+			"name":           "update-app",
+			"domain":         "wapp",
+			"tls_suite_name": "",
 		})
+
 		req := &ApplicationUpdateRequest{}
 		err := req.UpdateAppRequestFromSchema(context.Background(), d, ec)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid tls_suite_type value")
+		requireErrIs(t, err, false, nil)
+		assert.Nil(t, req.TLSSuiteName, "empty tls_suite_name should not be sent to the API")
 	})
 }
 

--- a/pkg/client/constants.go
+++ b/pkg/client/constants.go
@@ -242,9 +242,6 @@ var (
 	ErrTLSSuiteNotAvailableForAppType           = errors.New("TLS Suite configuration is not available for this app type")
 	ErrTLSSuiteNotAvailableForSMBProfile        = errors.New("TLS Suite configuration is not available for SMB profile")
 	ErrTLSSuiteNotAvailableForEnterpriseProfile = errors.New("TLS Suite configuration is not available for this enterprise profile")
-	ErrTLSSuiteNameRequired                     = errors.New("tls_suite_name is required for custom TLS Suite")
-	ErrTLSSuiteNameNotString                    = errors.New("tls_suite_name must be a string")
-	ErrTLSSuiteNameInvalid                      = errors.New("invalid tls_suite_name for custom TLS Suite")
 
 	// App cleanup errors
 	ErrAppCleanupIncomplete           = errors.New("app may still exist in EAA and needs manual cleanup")
@@ -853,13 +850,6 @@ const (
 	LoadBalancingIPHash     LoadBalancingMetric = "ip-hash"
 	LoadBalancingLeastConn  LoadBalancingMetric = "least-conn"
 	LoadBalancingWeightedRR LoadBalancingMetric = "weighted-rr"
-)
-
-type TLSSuiteType string
-
-const (
-	TLSSuiteTypeDefault TLSSuiteType = "default"
-	TLSSuiteTypeCustom  TLSSuiteType = "custom"
 )
 
 type CORSValue string

--- a/pkg/eaaprovider/app_read_helpers.go
+++ b/pkg/eaaprovider/app_read_helpers.go
@@ -113,6 +113,11 @@ func mapBasicAttributesFromResponse(ctx context.Context, d *schema.ResourceData,
 	}
 
 	attrs["uuid_url"] = appResp.UUIDURL
+	if appResp.TLSSuiteName != nil {
+		attrs["tls_suite_name"] = *appResp.TLSSuiteName
+	} else {
+		attrs["tls_suite_name"] = ""
+	}
 
 	var diags diag.Diagnostics
 	if appResp.AppBundle != "" {
@@ -336,7 +341,6 @@ func mapAdvancedSettingsFromResponse(d *schema.ResourceData, appResp *client.App
 		"ssh_audit_enabled":                  appResp.AdvancedSettings.SSHAuditEnabled,
 		"sso":                                appResp.AdvancedSettings.SSO,
 		"sticky_agent":                       appResp.AdvancedSettings.StickyAgent,
-		"tls_suite_name":                     derefStr(appResp.AdvancedSettings.TLSSuiteName),
 		"user_name":                          derefStr(appResp.AdvancedSettings.UserName),
 		"wapp_auth":                          appResp.AdvancedSettings.WappAuth,
 		"websocket_enabled":                  appResp.AdvancedSettings.WebSocketEnabled,
@@ -352,18 +356,6 @@ func mapAdvancedSettingsFromResponse(d *schema.ResourceData, appResp *client.App
 		return diag.Errorf("failed to map health_check_type from API value %q: %v", appResp.AdvancedSettings.HealthCheckType, err)
 	}
 	full["health_check_type"] = healthCheckType
-
-	// tls_suite_type: int -> descriptive string; always set so nil clears state.
-	switch {
-	case appResp.AdvancedSettings.TLSSuiteType == nil:
-		full["tls_suite_type"] = ""
-	case *appResp.AdvancedSettings.TLSSuiteType == 1:
-		full["tls_suite_type"] = "default"
-	case *appResp.AdvancedSettings.TLSSuiteType == 2:
-		full["tls_suite_type"] = "custom"
-	default:
-		return diag.Errorf("failed to map tls_suite_type from API value %d: must be one of [1, 2]", *appResp.AdvancedSettings.TLSSuiteType)
-	}
 
 	// form_post_attributes: []string -> JSON string.
 	// Write "[]" only when the key is already tracked in state, so clearing is reflected.

--- a/pkg/eaaprovider/app_read_helpers_test.go
+++ b/pkg/eaaprovider/app_read_helpers_test.go
@@ -1,12 +1,14 @@
 package eaaprovider
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"git.source.akamai.com/terraform-provider-eaa/pkg/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestMapAdvancedSettingsFromResponseWithInvalidHealthCheckType tests that
@@ -194,133 +196,6 @@ func TestMapAdvancedSettingsFromResponseWithValidHealthCheckType(t *testing.T) {
 	}
 }
 
-func TestMapAdvancedSettingsFromResponseWithInvalidTLSSuiteType(t *testing.T) {
-	invalidTLSSuiteType := 99
-
-	resourceSchema := map[string]*schema.Schema{
-		"uuid_url": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"app_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"host": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"advanced_settings": {
-			Type:     schema.TypeMap,
-			Optional: true,
-		},
-	}
-
-	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-		"uuid_url": "test-app-id",
-		"name":     "test-app",
-		"app_type": "http",
-		"host":     "test.example.com",
-		"advanced_settings": map[string]interface{}{
-			"tls_suite_type": "default",
-		},
-	})
-
-	appResp := &client.ApplicationResponse{
-		UUIDURL: "test-app-id",
-		Name:    "test-app",
-		AdvancedSettings: client.AdvancedSettingsComplete{
-			HealthCheckType: "0",
-			TLSSuiteType:    &invalidTLSSuiteType,
-		},
-	}
-
-	diags := mapAdvancedSettingsFromResponse(d, appResp)
-	if !diags.HasError() {
-		t.Fatalf("mapAdvancedSettingsFromResponse with invalid tls_suite_type returned no errors")
-	}
-	if len(diags) == 0 || !strings.Contains(diags[0].Summary, "tls_suite_type") {
-		t.Fatalf("expected diagnostic mentioning tls_suite_type, got: %+v", diags)
-	}
-}
-
-func TestMapAdvancedSettingsFromResponseWithValidTLSSuiteType(t *testing.T) {
-	tests := []struct {
-		name           string
-		tlsSuiteVal    *int
-		expectedResult string
-	}{
-		{name: "nil", tlsSuiteVal: nil, expectedResult: ""},
-		{name: "default", tlsSuiteVal: intPtr(1), expectedResult: "default"},
-		{name: "custom", tlsSuiteVal: intPtr(2), expectedResult: "custom"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resourceSchema := map[string]*schema.Schema{
-				"uuid_url": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"name": {
-					Type:     schema.TypeString,
-					Optional: true,
-				},
-				"app_type": {
-					Type:     schema.TypeString,
-					Optional: true,
-				},
-				"host": {
-					Type:     schema.TypeString,
-					Optional: true,
-				},
-				"advanced_settings": {
-					Type:     schema.TypeMap,
-					Optional: true,
-				},
-			}
-
-			d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-				"uuid_url": "test-app-id",
-				"name":     "test-app",
-				"app_type": "http",
-				"host":     "test.example.com",
-				"advanced_settings": map[string]interface{}{
-					"tls_suite_type": "default",
-				},
-			})
-
-			appResp := &client.ApplicationResponse{
-				UUIDURL: "test-app-id",
-				Name:    "test-app",
-				AdvancedSettings: client.AdvancedSettingsComplete{
-					HealthCheckType: "0",
-					TLSSuiteType:    tt.tlsSuiteVal,
-				},
-			}
-
-			diags := mapAdvancedSettingsFromResponse(d, appResp)
-			if diags.HasError() {
-				t.Fatalf("mapAdvancedSettingsFromResponse returned errors: %v", diags)
-			}
-
-			advSettingsRaw := d.Get("advanced_settings")
-			advSettings, ok := advSettingsRaw.(map[string]interface{})
-			if !ok {
-				t.Fatalf("advanced_settings type = %T, want map[string]interface{}", advSettingsRaw)
-			}
-
-			if got := advSettings["tls_suite_type"]; got != tt.expectedResult {
-				t.Fatalf("tls_suite_type = %q, want %q", got, tt.expectedResult)
-			}
-		})
-	}
-}
-
 func TestMapAdvancedSettingsFromResponse_FlexStringFields(t *testing.T) {
 	resourceSchema := map[string]*schema.Schema{
 		"uuid_url": {
@@ -377,6 +252,64 @@ func TestMapAdvancedSettingsFromResponse_FlexStringFields(t *testing.T) {
 	assert.Equal(t, "900", advSettings["x_wapp_read_timeout"])
 }
 
-func intPtr(v int) *int {
-	return &v
+func TestMapBasicAttributesFromResponse_TLSSuiteName(t *testing.T) {
+	basicSchema := map[string]*schema.Schema{
+		"name":            {Type: schema.TypeString, Optional: true},
+		"description":     {Type: schema.TypeString, Optional: true},
+		"app_profile":     {Type: schema.TypeString, Optional: true},
+		"app_type":        {Type: schema.TypeString, Optional: true},
+		"client_app_mode": {Type: schema.TypeString, Optional: true},
+		"domain":          {Type: schema.TypeString, Computed: true},
+		"domain_suffix":   {Type: schema.TypeString, Computed: true},
+		"host":            {Type: schema.TypeString, Optional: true, Computed: true},
+		"bookmark_url":    {Type: schema.TypeString, Optional: true},
+		"origin_host":     {Type: schema.TypeString, Optional: true, Computed: true},
+		"orig_tls":        {Type: schema.TypeBool, Computed: true},
+		"origin_port":     {Type: schema.TypeInt, Computed: true},
+		"pop":             {Type: schema.TypeString, Computed: true},
+		"popname":         {Type: schema.TypeString, Computed: true},
+		"popregion":       {Type: schema.TypeString, Optional: true, Computed: true},
+		"auth_enabled":    {Type: schema.TypeString, Optional: true},
+		"app_deployed":    {Type: schema.TypeBool, Computed: true},
+		"app_operational": {Type: schema.TypeInt, Computed: true},
+		"app_status":      {Type: schema.TypeInt, Computed: true},
+		"saml":            {Type: schema.TypeBool, Computed: true},
+		"oidc":            {Type: schema.TypeBool, Computed: true},
+		"wsfed":           {Type: schema.TypeBool, Computed: true},
+		"cname":           {Type: schema.TypeString, Computed: true},
+		"app_category":    {Type: schema.TypeString, Optional: true},
+		"cert":            {Type: schema.TypeString, Computed: true},
+		"uuid_url":        {Type: schema.TypeString, Computed: true},
+		"tls_suite_name":  {Type: schema.TypeString, Optional: true, Computed: true},
+		"app_bundle":      {Type: schema.TypeString, Optional: true},
+	}
+
+	t.Run("non-nil tls_suite_name is set", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, basicSchema, map[string]interface{}{})
+		suiteName := "my-tls-suite"
+		appResp := &client.ApplicationResponse{
+			UUIDURL:      "test-app-id",
+			Name:         "test-app",
+			TLSSuiteName: &suiteName,
+		}
+
+		diags := mapBasicAttributesFromResponse(context.Background(), d, appResp, nil)
+		require.False(t, diags.HasError(), "unexpected error: %v", diags)
+		assert.Equal(t, "my-tls-suite", d.Get("tls_suite_name"))
+	})
+
+	t.Run("nil tls_suite_name is cleared", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, basicSchema, map[string]interface{}{
+			"tls_suite_name": "old-suite",
+		})
+		appResp := &client.ApplicationResponse{
+			UUIDURL:      "test-app-id",
+			Name:         "test-app",
+			TLSSuiteName: nil,
+		}
+
+		diags := mapBasicAttributesFromResponse(context.Background(), d, appResp, nil)
+		require.False(t, diags.HasError(), "unexpected error: %v", diags)
+		assert.Equal(t, "", d.Get("tls_suite_name"))
+	})
 }

--- a/pkg/eaaprovider/resource_eaa_application.go
+++ b/pkg/eaaprovider/resource_eaa_application.go
@@ -137,6 +137,11 @@ func resourceEaaApplication() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"tls_suite_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 
 			"domain": {
 				Type:     schema.TypeString,
@@ -757,29 +762,24 @@ func resourceEaaApplication() *schema.Resource {
 
 			"app_operational": {
 				Type:     schema.TypeInt,
-				Optional: true,
 				Computed: true,
 			},
 			"app_status": {
 				Type:     schema.TypeInt,
-				Optional: true,
 				Computed: true,
 			},
 
 			"app_deployed": {
 				Type:     schema.TypeBool,
-				Optional: true,
 				Computed: true,
 			},
 			"cname": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"uuid_url": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
@@ -810,10 +810,6 @@ func resourceEaaApplication() *schema.Resource {
 				Type:      schema.TypeString,
 				Computed:  true,
 				Sensitive: true,
-			},
-			"generate_self_signed_cert": {
-				Type:     schema.TypeBool,
-				Optional: true,
 			},
 			"advanced_settings": {
 				Type:             schema.TypeMap,
@@ -1212,16 +1208,16 @@ func resourceEaaApplicationUpdate(ctx context.Context, d *schema.ResourceData, m
 					return append(warningDiags, logging.DiagFromErr(ErrInvalidData, tags, "authentication data is nil")...)
 				}
 				if len(appAuthList) > 0 {
-					appAuthenticationMap, ok := appAuthList[0].(map[string]interface{})
-					if !ok {
+					appAuthenticationMap, mapOK := appAuthList[0].(map[string]interface{})
+					if !mapOK {
+						logging.Error(ctx, "app_authentication block has unexpected type in UPDATE", tags)
 						return append(warningDiags, logging.DiagFromErr(ErrInvalidData, tags, "invalid authentication map data")...)
 					}
 					if appAuthenticationMap == nil {
-						logging.Warn(ctx, "invalid authentication data", tags)
-						return append(warningDiags, logging.DiagFromErr(ErrInvalidData, tags, "authentication map is nil")...)
+						logging.Debug(ctx, "app_authentication block is empty in UPDATE, skipping", tags)
+						return warningDiags
 					}
-
-					if appIDPName, ok := appAuthenticationMap["app_idp"].(string); ok {
+					if appIDPName, ok := appAuthenticationMap["app_idp"].(string); ok && appIDPName != "" {
 						idpData, getIDPErr := client.GetIdpWithName(ctx, eaaclient, appIDPName)
 						if getIDPErr != nil {
 							logging.Warn(ctx, "get IDP with name error", tags, map[string]any{"error": getIDPErr.Error()})

--- a/pkg/eaaprovider/resource_eaa_application_test.go
+++ b/pkg/eaaprovider/resource_eaa_application_test.go
@@ -41,10 +41,9 @@ func TestResourceEaaApplication_Schema(t *testing.T) {
 			"servers", "popregion",
 			"auth_enabled", "agents", "app_category",
 			"cert_name", "cert_type",
-			"generate_self_signed_cert", "advanced_settings",
+			"advanced_settings",
 			"app_bundle", "service", "client_app_mode",
-			"app_operational", "app_status", "app_deployed",
-			"cname", "uuid_url",
+			"tls_suite_name",
 		}
 		for _, field := range optionalFields {
 			f, exists := r.Schema[field]
@@ -70,7 +69,10 @@ func TestResourceEaaApplication_Schema(t *testing.T) {
 	})
 
 	t.Run("computed-only fields", func(t *testing.T) {
-		for _, field := range []string{"domain_suffix", "pop", "popname", "cert", "cert_body"} {
+		for _, field := range []string{
+			"domain_suffix", "pop", "popname", "cert", "cert_body",
+			"app_operational", "app_status", "app_deployed", "cname", "uuid_url",
+		} {
 			assert.True(t, r.Schema[field].Computed, "field %q must be computed", field)
 			assert.False(t, r.Schema[field].Optional, "field %q must not be optional", field)
 		}
@@ -1214,16 +1216,13 @@ func TestCreateAppRequestFromSchema(t *testing.T) {
 		assert.Empty(t, req.SAMLSettings)
 	})
 
-	t.Run("tls_suite_configuration", func(t *testing.T) {
+	t.Run("tls_suite_name_top_level", func(t *testing.T) {
 		mockClient, _ := createMockClient(t)
 		d := createTestApplicationResourceData(t, map[string]interface{}{
-			"name":        "tls-app",
-			"app_type":    "enterprise",
-			"app_profile": "http",
-			"advanced_settings": map[string]interface{}{
-				"tls_suite_type": "custom",
-				"tls_suite_name": "my-suite",
-			},
+			"name":           "tls-app",
+			"app_type":       "enterprise",
+			"app_profile":    "http",
+			"tls_suite_name": "my-suite",
 		})
 
 		var req client.CreateAppRequest
@@ -1231,29 +1230,23 @@ func TestCreateAppRequestFromSchema(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "tls-app", req.Name)
-		require.NotNil(t, req.TLSSuiteType)
-		assert.Equal(t, 2, *req.TLSSuiteType) // "custom" -> 2
 		require.NotNil(t, req.TLSSuiteName)
 		assert.Equal(t, "my-suite", *req.TLSSuiteName)
 	})
 
-	t.Run("tls_suite_default", func(t *testing.T) {
+	t.Run("tls_suite_name_omitted", func(t *testing.T) {
 		mockClient, _ := createMockClient(t)
 		d := createTestApplicationResourceData(t, map[string]interface{}{
 			"name":        "tls-default-app",
 			"app_type":    "enterprise",
 			"app_profile": "http",
-			"advanced_settings": map[string]interface{}{
-				"tls_suite_type": "default",
-			},
 		})
 
 		var req client.CreateAppRequest
 		err := req.CreateAppRequestFromSchema(ctx, d, mockClient)
 		require.NoError(t, err)
 
-		require.NotNil(t, req.TLSSuiteType)
-		assert.Equal(t, 1, *req.TLSSuiteType) // "default" -> 1
+		assert.Nil(t, req.TLSSuiteName)
 	})
 
 	t.Run("missing_name_returns_error", func(t *testing.T) {
@@ -1399,21 +1392,16 @@ func TestUpdateAppRequestFromSchema(t *testing.T) {
 	t.Run("tls_suite_updates", func(t *testing.T) {
 		mockClient, _ := createMockClient(t)
 		d := createTestApplicationResourceData(t, map[string]interface{}{
-			"name":     "tls-update-app",
-			"app_type": "enterprise",
-			"domain":   "wapp",
-			"advanced_settings": map[string]interface{}{
-				"tls_suite_type": "custom",
-				"tls_suite_name": "updated-suite",
-			},
+			"name":           "tls-update-app",
+			"app_type":       "enterprise",
+			"domain":         "wapp",
+			"tls_suite_name": "updated-suite",
 		})
 
 		var req client.ApplicationUpdateRequest
 		err := req.UpdateAppRequestFromSchema(ctx, d, mockClient)
 		require.NoError(t, err)
 
-		require.NotNil(t, req.TLSSuiteType)
-		assert.Equal(t, 2, *req.TLSSuiteType)
 		require.NotNil(t, req.TLSSuiteName)
 		assert.Equal(t, "updated-suite", *req.TLSSuiteName)
 	})
@@ -1581,20 +1569,4 @@ func TestUpdateAppRequestFromSchema(t *testing.T) {
 		assert.True(t, req.WSFED)
 	})
 
-	t.Run("invalid_tls_suite_type_returns_error", func(t *testing.T) {
-		mockClient, _ := createMockClient(t)
-		d := createTestApplicationResourceData(t, map[string]interface{}{
-			"name":     "bad-tls-app",
-			"app_type": "enterprise",
-			"domain":   "wapp",
-			"advanced_settings": map[string]interface{}{
-				"tls_suite_type": "invalid",
-			},
-		})
-
-		var req client.ApplicationUpdateRequest
-		err := req.UpdateAppRequestFromSchema(ctx, d, mockClient)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid tls_suite_type")
-	})
 }


### PR DESCRIPTION
  - Promote tls_suite_name from advanced_settings map to a top-level
    Optional+Computed schema attribute for both CREATE and UPDATE flows
  - Remove tls_suite_type (and its default/custom integer mapping) entirely
  - Remove generate_self_signed_cert field (cert handling is now automatic)
  - Change app_operational, app_status, app_deployed, cname, uuid_url
    from Optional+Computed to Computed-only
  - Improve auth block nil-handling and error messages
  - Add empty-string tls_suite_name guard with tests
  - Update docs with TLS behavior notes and cert_type clarifications