### PR TITLE
fix: treat eaa_application.servers as an unordered set (#65)

### DIFF
--- a/pkg/client/application.go
+++ b/pkg/client/application.go
@@ -1452,8 +1452,9 @@ func (appUpdateReq *ApplicationUpdateRequest) UpdateAppRequestFromSchema(ctx con
 
 	appUpdateReq.Servers = []Server{}
 	if servers, ok := d.GetOk("servers"); ok {
-		if serversList, ok := servers.([]interface{}); ok {
-			for _, s := range serversList {
+		// "servers" is a TypeSet, so GetOk returns a *schema.Set.
+		if serversSet, ok := servers.(*schema.Set); ok {
+			for _, s := range serversSet.List() {
 				sData, ok := s.(map[string]interface{})
 				if !ok {
 					logging.Warn(ctx, "skipping malformed server entry", tags)

--- a/pkg/eaaprovider/app_read_mapping_test.go
+++ b/pkg/eaaprovider/app_read_mapping_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"git.source.akamai.com/terraform-provider-eaa/pkg/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -84,10 +85,16 @@ func TestMapServersAndTunnelHostsFromResponse(t *testing.T) {
 		diags := mapServersAndTunnelHostsFromResponse(d, appResp)
 		require.False(t, diags.HasError())
 
-		serversRaw := d.Get("servers").([]interface{})
+		// servers is a TypeSet (unordered), so index by origin_host rather than position.
+		serversRaw := d.Get("servers").(*schema.Set).List()
 		require.Len(t, serversRaw, 2)
-		first := serversRaw[0].(map[string]interface{})
-		assert.Equal(t, "srv1.internal", first["origin_host"])
+		byHost := make(map[string]map[string]interface{}, len(serversRaw))
+		for _, s := range serversRaw {
+			m := s.(map[string]interface{})
+			byHost[m["origin_host"].(string)] = m
+		}
+		require.Contains(t, byHost, "srv1.internal")
+		first := byHost["srv1.internal"]
 		assert.Equal(t, true, first["orig_tls"])
 		assert.Equal(t, 443, first["origin_port"])
 		assert.Equal(t, "https", first["origin_protocol"])

--- a/pkg/eaaprovider/resource_eaa_application.go
+++ b/pkg/eaaprovider/resource_eaa_application.go
@@ -29,6 +29,21 @@ var jsonStringAdvancedSettingsKeys = map[string]bool{
 	"rdp_remote_apps":      true,
 }
 
+// serversSetHash hashes a "servers" element on its user-meaningful fields only.
+// orig_tls is intentionally excluded: it is Optional+Computed (derived by the API
+// from origin_protocol), so including it would make an unset config value hash
+// differently from the API-populated state value and reintroduce a perpetual diff.
+func serversSetHash(v interface{}) int {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return 0
+	}
+	host, _ := m["origin_host"].(string)
+	port, _ := m["origin_port"].(int)
+	protocol, _ := m["origin_protocol"].(string)
+	return schema.HashString(fmt.Sprintf("%s-%d-%s", host, port, protocol))
+}
+
 // suppressServerComputedAdvSettingsKey suppresses plan diffs for:
 //  1. API-auto-populated keys (e.g. edge_cookie_key) the user never configured.
 //  2. JSON-string fields where only key-order or whitespace differs.
@@ -191,8 +206,9 @@ func resourceEaaApplication() *schema.Resource {
 				},
 			},
 			"servers": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
+				Set:      serversSetHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"origin_host": {

--- a/pkg/eaaprovider/resource_eaa_application.go
+++ b/pkg/eaaprovider/resource_eaa_application.go
@@ -38,9 +38,9 @@ func serversSetHash(v interface{}) int {
 	if !ok {
 		return 0
 	}
-	host, _ := m["origin_host"].(string)
-	port, _ := m["origin_port"].(int)
-	protocol, _ := m["origin_protocol"].(string)
+	host, _ := m["origin_host"].(string)         //nolint:errcheck // zero-value is safe for hashing
+	port, _ := m["origin_port"].(int)            //nolint:errcheck // zero-value is safe for hashing
+	protocol, _ := m["origin_protocol"].(string) //nolint:errcheck // zero-value is safe for hashing
 	return schema.HashString(fmt.Sprintf("%s-%d-%s", host, port, protocol))
 }
 

--- a/pkg/eaaprovider/resource_eaa_application_test.go
+++ b/pkg/eaaprovider/resource_eaa_application_test.go
@@ -1456,8 +1456,9 @@ func TestUpdateAppRequestFromSchema(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, req.Servers, 2)
-		assert.Equal(t, "backend1.internal", req.Servers[0].OriginHost)
-		assert.Equal(t, "backend2.internal", req.Servers[1].OriginHost)
+		// servers is a TypeSet, so order is not guaranteed; assert by membership.
+		hosts := []string{req.Servers[0].OriginHost, req.Servers[1].OriginHost}
+		assert.ElementsMatch(t, []string{"backend1.internal", "backend2.internal"}, hosts)
 	})
 
 	t.Run("bookmark_url_set", func(t *testing.T) {

--- a/pkg/eaaprovider/servers_unordered_test.go
+++ b/pkg/eaaprovider/servers_unordered_test.go
@@ -1,0 +1,45 @@
+package eaaprovider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+// Origin servers are a load-balanced pool: the EAA API returns them in an
+// arbitrary order, so the schema must treat [A,B] and [B,A] as equal to avoid a
+// perpetual `terraform plan` diff. This requires the "servers" attribute to be a
+// TypeSet whose hash ignores the API-computed orig_tls field.
+func TestServersAttributeIsUnordered(t *testing.T) {
+	serversSchema := resourceEaaApplication().Schema["servers"]
+
+	require.Equal(t, schema.TypeSet, serversSchema.Type,
+		"servers must be a TypeSet so origin order does not produce a diff")
+	require.NotNil(t, serversSchema.Set, "servers must define a Set hash function")
+
+	hash := serversSchema.Set
+	serverA := map[string]interface{}{
+		"origin_host": "10.114.11.11", "origin_port": 443, "origin_protocol": "https", "orig_tls": true,
+	}
+	serverB := map[string]interface{}{
+		"origin_host": "10.114.11.12", "origin_port": 443, "origin_protocol": "https", "orig_tls": true,
+	}
+
+	configOrder := schema.NewSet(hash, []interface{}{serverA, serverB})
+	apiOrder := schema.NewSet(hash, []interface{}{serverB, serverA})
+	require.True(t, configOrder.Equal(apiOrder),
+		"reordered servers must be equal: [A,B] vs [B,A] should not diff")
+
+	// orig_tls is Optional+Computed (derived by the API). It must not affect the
+	// hash, otherwise an unset config value vs an API-populated state value would
+	// reintroduce the very diff this fix removes.
+	withTLS := map[string]interface{}{
+		"origin_host": "10.114.11.11", "origin_port": 443, "origin_protocol": "https", "orig_tls": true,
+	}
+	withoutTLS := map[string]interface{}{
+		"origin_host": "10.114.11.11", "origin_port": 443, "origin_protocol": "https", "orig_tls": false,
+	}
+	require.Equal(t, hash(withTLS), hash(withoutTLS),
+		"orig_tls must be excluded from the servers hash")
+}


### PR DESCRIPTION
Hi! 👋 Fix for #65.

`eaa_application.servers` was a `TypeList`, but origin servers are an unordered
pool when the EAA API returns them in a different order than the config, every
`plan` reports a change and the diff never converges.

### Change
- `servers` → `TypeSet` with a hash on `origin_host` / `origin_port` /
  `origin_protocol`.
- `orig_tls` is excluded from the hash: it's `Optional+Computed` (the API derives
  it from `origin_protocol`), so hashing it would make an unset config value
  differ from the API-populated state value and bring the diff back.
- Update marshalling now reads the `*schema.Set` instead of `[]interface{}`.

### Notes
- No state migration: Terraform stores both a list and a set as a JSON array, and
  Read repopulates the attribute on refresh.
- Added a unit test covering reorder-equality and the `orig_tls` exclusion.

Thanks!
