### PR TITLE
BWVONE-49392: introduce new create pattern for edge_auth and g2o, and add diags for server computed fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,8 @@ Manages the full lifecycle of an EAA application including servers, authenticati
 - `protocol` (SaaS top-level field) is case-sensitive — `wsfed` is NOT valid; use `WSFed` or `WS-Federation`. Note: `advanced_settings.app_auth` does accept lowercase aliases like `wsfed`, `saml`, `oidc`
 - `tls_suite_name = ""` (empty string) has no effect — the API ignores it
 - `advanced_settings` accepts any key the EAA API supports, not just the ones documented
+- Server-computed keys (`g2o_key`, `g2o_nonce`, `edge_cookie_key`, `sla_object_url`, `edge_transport_property_id`) are **read-only** — user-provided values are stripped and a warning is emitted. These values are always available in state for outputs.
+- `edge_authentication_enabled` on create uses a two-step PUT (false then true) — the provider handles this transparently
 
 Full reference: [docs/eaa_application.md](docs/eaa_application.md)
 
@@ -326,6 +328,7 @@ When helping users compose Terraform configurations for this provider:
    - SaaS apps use `protocol` field, enterprise apps use `advanced_settings.app_auth`
    - `protocol` values are case-sensitive: `WSFed` or `WS-Federation`, NOT `wsfed`
    - Registration token `expires_at` with `:00` seconds is automatically bumped to `:01` — use `:01` directly to avoid plan diffs
+   - Never set server-computed keys (`g2o_key`, `g2o_nonce`, `edge_cookie_key`, `sla_object_url`, `edge_transport_property_id`) — the provider strips them and warns. They are available in state for outputs.
 
 5. **When unsure about advanced settings**, point the user to the full list in `docs/eaa_application.md`. The `advanced_settings` map accepts any key the EAA API supports.
 

--- a/docs/eaa_application.md
+++ b/docs/eaa_application.md
@@ -94,6 +94,37 @@ Manages the lifecycle of an EAA application.
 * `uuid_url` - App UUID.
 * `domain_suffix` - Domain suffix.
 
+### Server-Computed Advanced Settings Keys
+
+The following `advanced_settings` keys are **read-only** — they are auto-populated by the EAA API and always available in Terraform state for use in outputs or references:
+
+| Key | Description |
+|-----|-------------|
+| `g2o_key` | G2O authentication key |
+| `g2o_nonce` | G2O authentication nonce |
+| `edge_cookie_key` | Edge authentication cookie key |
+| `sla_object_url` | SLA object URL |
+| `edge_transport_property_id` | Edge transport property identifier |
+
+**Behavior:**
+- If you set any of these keys in your configuration, the provider emits a **diagnostic warning** during apply and the value is **silently stripped** from the outgoing API request.
+- The API-computed values are always stored in Terraform state regardless of whether they appear in your configuration.
+- Plan diffs for these keys are automatically suppressed when the new value is empty.
+
+**Example — referencing a computed key in an output:**
+
+```hcl
+resource "eaa_application" "web_app" {
+  name = "Web App"
+  # ...
+}
+
+output "g2o_key" {
+  value     = eaa_application.web_app.advanced_settings["g2o_key"]
+  sensitive = true
+}
+```
+
 ## Advanced Settings
 
 Flat map of key/value string pairs passed via `advanced_settings`. Organized by category below.
@@ -173,7 +204,7 @@ The `advanced_settings` map also accepts keys not listed here — any key the EA
 * `websocket_enabled` - WebSocket support. Default `false`.
 * `x_wapp_read_timeout` - Read timeout in seconds. Default `900`.
 * `ignore_cname_resolution` - Ignore CNAME resolution for CDN access.
-* `g2o_enabled` - Enable G2O for Akamai Edge Enforcement.
+* `g2o_enabled` - Enable G2O for Akamai Edge Enforcement. On **create**, the provider ensures G2O is configured only after `edge_authentication_enabled` is fully applied, since G2O depends on edge authentication being active.
 * `internal_hostname` - Internal hostname.
 * `internal_host_port` - Internal host port.
 
@@ -188,7 +219,7 @@ The `advanced_settings` map also accepts keys not listed here — any key the EA
 
 ### Security
 
-* `edge_authentication_enabled` - Enable edge authentication. Default `true`.
+* `edge_authentication_enabled` - Enable edge authentication. Default `true`. On **create**, the provider automatically handles a two-step enablement: it first creates the application with edge authentication disabled, then enables it in a second update. This is required because the API rejects `edge_authentication_enabled = "true"` on a freshly created application. No user action is needed — the provider handles this transparently.
 * `ip_access_allow` - Enable IP-based access control.
 * `hsts_age` - HSTS max-age in seconds. Default `15552000`.
 * `http_only_cookie` - Set cookies as HTTP-only. Default `true`.

--- a/docs/eaa_application.md
+++ b/docs/eaa_application.md
@@ -219,7 +219,7 @@ The `advanced_settings` map also accepts keys not listed here — any key the EA
 
 ### Security
 
-* `edge_authentication_enabled` - Enable edge authentication. Default `true`. On **create**, the provider automatically handles a two-step enablement: it first creates the application with edge authentication disabled, then enables it in a second update. This is required because the API rejects `edge_authentication_enabled = "true"` on a freshly created application. No user action is needed — the provider handles this transparently.
+* `edge_authentication_enabled` - Enable edge authentication. Default `false`. But when `true` on **create**, the provider automatically handles a two-step enablement: it first creates the application with edge authentication disabled, then enables it in a second update. This is required because the API rejects `edge_authentication_enabled = "true"` on a freshly created application. No user action is needed — the provider handles this transparently.
 * `ip_access_allow` - Enable IP-based access control.
 * `hsts_age` - HSTS max-age in seconds. Default `15552000`.
 * `http_only_cookie` - Set cookies as HTTP-only. Default `true`.

--- a/pkg/client/app_advanced_settings.go
+++ b/pkg/client/app_advanced_settings.go
@@ -8,6 +8,17 @@ import (
 	"strings"
 )
 
+// ServerComputedAdvancedSettingsKeys are keys the API auto-populates.
+// User-provided values for these keys are stripped from outgoing requests
+// and a diagnostic warning is emitted.
+var ServerComputedAdvancedSettingsKeys = map[string]bool{
+	"g2o_key":                    true,
+	"g2o_nonce":                  true,
+	"edge_cookie_key":            true,
+	"sla_object_url":             true,
+	"edge_transport_property_id": true,
+}
+
 // ParseAdvancedSettingsWithDefaults parses JSON advanced settings and applies sensible defaults
 func ParseAdvancedSettingsWithDefaults(jsonStr string) (*AdvancedSettings, error) {
 	var userSettings map[string]interface{}
@@ -178,6 +189,11 @@ func advancedSettingsFromBlock(block map[string]interface{}) (*AdvancedSettings,
 	flat := make(map[string]interface{}, len(block))
 	for k, v := range block {
 		flat[k] = v
+	}
+
+	// Strip server-computed keys — the API auto-populates these.
+	for k := range ServerComputedAdvancedSettingsKeys {
+		delete(flat, k)
 	}
 
 	// form_post_attributes: stored as JSON string in TypeMap; decode to []interface{} for reflection.

--- a/pkg/client/app_advanced_settings_test.go
+++ b/pkg/client/app_advanced_settings_test.go
@@ -444,3 +444,28 @@ func TestParseAdvancedSettingsWithDefaults_NewFieldDefaults(t *testing.T) {
 	assert.Equal(t, "false", advSettings.ProxyDisableClipboard)
 	assert.Equal(t, "on", advSettings.RateLimit)
 }
+
+func TestAdvancedSettingsFromBlock_StripsComputedKeys(t *testing.T) {
+	block := map[string]interface{}{
+		"acceleration":               "true",
+		"g2o_key":                    "user-should-not-set-this",
+		"g2o_nonce":                  "nor-this",
+		"edge_cookie_key":            "nor-this-either",
+		"sla_object_url":             "ignore-me",
+		"edge_transport_property_id": "also-ignored",
+	}
+
+	advSettings, err := advancedSettingsFromBlock(block)
+	require.NoError(t, err)
+
+	// Verify user-settable keys are preserved
+	assert.Equal(t, "true", advSettings.Acceleration)
+
+	// Verify server-computed keys are NOT set from user input
+	// (they retain their default/zero values)
+	assert.Nil(t, advSettings.G2OKey)
+	assert.Nil(t, advSettings.G2ONonce)
+	assert.Nil(t, advSettings.EdgeCookieKey)
+	assert.Nil(t, advSettings.SLAObjectURL)
+	assert.Nil(t, advSettings.EdgeTransportPropertyID)
+}

--- a/pkg/client/application.go
+++ b/pkg/client/application.go
@@ -670,7 +670,7 @@ func ConfigureAuthentication(ctx context.Context, appID string, d *schema.Resour
 }
 
 // ConfigureAdvancedSettings configures advanced settings for an existing application
-func ConfigureAdvancedSettings(ctx context.Context, appID string, d *schema.ResourceData, ec *EaaClient) error {
+func ConfigureAdvancedSettings(ctx context.Context, appID string, d *schema.ResourceData, ec *EaaClient, isCreate bool) error {
 	tags := []logging.Tag{logging.TagAPI, logging.TagApp, logging.TagUpdate}
 
 	// Create update request with advanced settings
@@ -711,10 +711,44 @@ func ConfigureAdvancedSettings(ctx context.Context, appID string, d *schema.Reso
 		}
 	}
 
-	// Apply the update
+	// Detect if edge_authentication_enabled needs a two-step dance on create.
+	// The API rejects edge_authentication_enabled=true on a freshly created app.
+	// Workaround: first PUT with false, then second PUT with true.
+	needsEdgeAuthDance := isCreate && updateRequest.AdvancedSettings.EdgeAuthenticationEnabled == STR_TRUE
+
+	if needsEdgeAuthDance {
+		logging.Debug(ctx, "edge_authentication_enabled=true on create: performing two-step dance", tags)
+		updateRequest.AdvancedSettings.EdgeAuthenticationEnabled = STR_FALSE
+	}
+
+	// Apply the update (first PUT — with edge_auth forced to false if dance is needed)
 	err = updateRequest.UpdateApplication(ctx, ec)
 	if err != nil {
 		return logging.Wrapf(err, tags, "failed to apply advanced settings")
+	}
+
+	if needsEdgeAuthDance {
+		logging.Debug(ctx, "second PUT: enabling edge_authentication_enabled", tags)
+		updateRequest.AdvancedSettings.EdgeAuthenticationEnabled = STR_TRUE
+		err = updateRequest.UpdateApplication(ctx, ec)
+		if err != nil {
+			return logging.Wrapf(err, tags, "failed to enable edge_authentication_enabled on second PUT")
+		}
+	}
+
+	// G2O requires edge_authentication_enabled=true, so it must run after the edge auth dance.
+	if updateRequest.AdvancedSettings.G2OEnabled == STR_TRUE {
+		logging.Debug(ctx, "g2o_enabled=true: calling UpdateG2O", tags)
+		g2oResp, g2oErr := updateRequest.UpdateG2O(ctx, ec)
+		if g2oErr != nil {
+			return logging.Wrapf(g2oErr, tags, "g2o request failed")
+		}
+		updateRequest.AdvancedSettings.G2OKey = &g2oResp.G2OKey
+		updateRequest.AdvancedSettings.G2ONonce = &g2oResp.G2ONonce
+		err = updateRequest.UpdateApplication(ctx, ec)
+		if err != nil {
+			return logging.Wrapf(err, tags, "failed to apply G2O settings")
+		}
 	}
 
 	logging.Debug(ctx, "configure advanced settings succeeded", tags)
@@ -900,7 +934,7 @@ func (app *Application) UpdateG2O(ctx context.Context, ec *EaaClient) (*G2ORespo
 	apiURL := fmt.Sprintf("%s://%s/%s/%s/g2o", URL_SCHEME, ec.Host, APPS_URL, app.UUIDURL)
 
 	var g2oResp G2OResponse
-	g2ohttpResp, err := ec.SendAPIRequest(ctx, apiURL, "POST", nil, &g2oResp, false)
+	g2ohttpResp, err := ec.SendAPIRequest(ctx, apiURL, "POST", map[string]interface{}{}, &g2oResp, false)
 	if err != nil {
 		return nil, logging.Wrapf(err, tags, "g2o request failed")
 	}
@@ -1211,27 +1245,6 @@ func (appUpdateReq *ApplicationUpdateRequest) UpdateAppRequestFromSchema(ctx con
 
 		// Note: SAML/OIDC/WS-FED settings are now handled outside this block
 		// to ensure they run regardless of whether advanced_settings is provided
-
-		// Handle special cases that require API calls
-		if advSettings.G2OEnabled == STR_TRUE {
-			g2oResp, err := appUpdateReq.UpdateG2O(ctx, ec)
-			if err != nil {
-				logging.Error(ctx, "g2o request failed", tags, map[string]any{"error": err.Error()})
-				return err
-			}
-			advSettings.G2OKey = &g2oResp.G2OKey
-			advSettings.G2ONonce = &g2oResp.G2ONonce
-		}
-
-		if advSettings.EdgeAuthenticationEnabled == STR_TRUE {
-			edgeAuthResp, err := appUpdateReq.UpdateEdgeAuthentication(ctx, ec)
-			if err != nil {
-				logging.Error(ctx, "edge auth cookie request failed", tags, map[string]any{"error": err.Error()})
-				return err
-			}
-			advSettings.EdgeCookieKey = &edgeAuthResp.EdgeCookieKey
-			advSettings.SLAObjectURL = &edgeAuthResp.SLAObjectURL
-		}
 
 		// Use the UpdateAdvancedSettings function to properly update the struct
 		UpdateAdvancedSettings(&appUpdateReq.AdvancedSettings, advSettings)

--- a/pkg/client/application_test.go
+++ b/pkg/client/application_test.go
@@ -849,16 +849,9 @@ func TestConfigureAdvancedSettings(t *testing.T) {
 			Optional: true,
 		},
 		"advanced_settings": {
-			Type:     schema.TypeList,
+			Type:     schema.TypeMap,
 			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"app_auth": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
+			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 	}
 
@@ -878,7 +871,7 @@ func TestConfigureAdvancedSettings(t *testing.T) {
 				"description":       "",
 				"host":              "",
 				"auth_enabled":      "false",
-				"advanced_settings": []interface{}{},
+				"advanced_settings": map[string]interface{}{"app_auth": "SAML2.0"},
 			},
 			setupRouter: func(pr *pathRouter) {
 				pr.Handle("GET", "/crux/v1/mgmt-pop/apps/app-42", jsonHandler(http.StatusOK, appGetResp))
@@ -893,7 +886,7 @@ func TestConfigureAdvancedSettings(t *testing.T) {
 				"description":       "",
 				"host":              "",
 				"auth_enabled":      "false",
-				"advanced_settings": []interface{}{},
+				"advanced_settings": map[string]interface{}{"app_auth": "SAML2.0"},
 			},
 			setupRouter: func(pr *pathRouter) {
 				pr.Handle("GET", "/crux/v1/mgmt-pop/apps/app-42",
@@ -907,7 +900,7 @@ func TestConfigureAdvancedSettings(t *testing.T) {
 				"description":       "",
 				"host":              "",
 				"auth_enabled":      "false",
-				"advanced_settings": []interface{}{},
+				"advanced_settings": map[string]interface{}{"app_auth": "SAML2.0"},
 			},
 			setupRouter: func(pr *pathRouter) {
 				pr.Handle("GET", "/crux/v1/mgmt-pop/apps/app-42", jsonHandler(http.StatusOK, appGetResp))

--- a/pkg/client/application_test.go
+++ b/pkg/client/application_test.go
@@ -926,7 +926,7 @@ func TestConfigureAdvancedSettings(t *testing.T) {
 
 			d := schema.TestResourceDataRaw(t, advancedSchema, tt.values)
 
-			err := ConfigureAdvancedSettings(context.Background(), "app-42", d, ec)
+			err := ConfigureAdvancedSettings(context.Background(), "app-42", d, ec, false)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -934,6 +934,207 @@ func TestConfigureAdvancedSettings(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestConfigureAdvancedSettings_EdgeAuthCreateDance(t *testing.T) {
+	advancedSchema := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"host": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"auth_enabled": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"advanced_settings": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+	}
+
+	appGetResp := ApplicationResponse{
+		Name:    "my-app",
+		UUIDURL: "app-42",
+	}
+
+	var putCount int
+
+	t.Run("isCreate_true_edge_auth_enabled_does_two_PUTs", func(t *testing.T) {
+		putCount = 0
+		pr := newPathRouter(t)
+		pr.Handle("GET", "/crux/v1/mgmt-pop/apps/app-42", jsonHandler(http.StatusOK, appGetResp))
+		pr.Handle("PUT", "/crux/v1/mgmt-pop/apps/app-42", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			putCount++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"name": "my-app"})
+		}))
+		ec := newTestClient(t, pr)
+
+		d := schema.TestResourceDataRaw(t, advancedSchema, map[string]interface{}{
+			"name":         "my-app",
+			"description":  "",
+			"host":         "",
+			"auth_enabled": "false",
+			"advanced_settings": map[string]interface{}{
+				"edge_authentication_enabled": "true",
+			},
+		})
+
+		err := ConfigureAdvancedSettings(context.Background(), "app-42", d, ec, true)
+		require.NoError(t, err)
+		assert.Equal(t, 2, putCount, "expected two PUT calls for edge auth create dance")
+	})
+
+	t.Run("isCreate_false_edge_auth_enabled_does_one_PUT", func(t *testing.T) {
+		putCount = 0
+		pr := newPathRouter(t)
+		pr.Handle("GET", "/crux/v1/mgmt-pop/apps/app-42", jsonHandler(http.StatusOK, appGetResp))
+		pr.Handle("PUT", "/crux/v1/mgmt-pop/apps/app-42", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			putCount++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"name": "my-app"})
+		}))
+		ec := newTestClient(t, pr)
+
+		d := schema.TestResourceDataRaw(t, advancedSchema, map[string]interface{}{
+			"name":         "my-app",
+			"description":  "",
+			"host":         "",
+			"auth_enabled": "false",
+			"advanced_settings": map[string]interface{}{
+				"edge_authentication_enabled": "true",
+			},
+		})
+
+		err := ConfigureAdvancedSettings(context.Background(), "app-42", d, ec, false)
+		require.NoError(t, err)
+		assert.Equal(t, 1, putCount, "expected one PUT call for non-create flow")
+	})
+
+	t.Run("isCreate_true_edge_auth_false_does_one_PUT", func(t *testing.T) {
+		putCount = 0
+		pr := newPathRouter(t)
+		pr.Handle("GET", "/crux/v1/mgmt-pop/apps/app-42", jsonHandler(http.StatusOK, appGetResp))
+		pr.Handle("PUT", "/crux/v1/mgmt-pop/apps/app-42", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			putCount++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"name": "my-app"})
+		}))
+		ec := newTestClient(t, pr)
+
+		d := schema.TestResourceDataRaw(t, advancedSchema, map[string]interface{}{
+			"name":         "my-app",
+			"description":  "",
+			"host":         "",
+			"auth_enabled": "false",
+			"advanced_settings": map[string]interface{}{
+				"edge_authentication_enabled": "false",
+			},
+		})
+
+		err := ConfigureAdvancedSettings(context.Background(), "app-42", d, ec, true)
+		require.NoError(t, err)
+		assert.Equal(t, 1, putCount, "expected one PUT call when edge auth is false even on create")
+	})
+
+	t.Run("isCreate_true_edge_auth_and_g2o_does_g2o_after_dance", func(t *testing.T) {
+		putCount = 0
+		var g2oCount int
+		var callOrder []string
+		pr := newPathRouter(t)
+		pr.Handle("GET", "/crux/v1/mgmt-pop/apps/app-42", jsonHandler(http.StatusOK, appGetResp))
+		pr.Handle("PUT", "/crux/v1/mgmt-pop/apps/app-42", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			putCount++
+			callOrder = append(callOrder, "PUT")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"name": "my-app"})
+		}))
+		pr.Handle("POST", "/crux/v1/mgmt-pop/apps/app-42/g2o", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			g2oCount++
+			callOrder = append(callOrder, "G2O")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(G2OResponse{
+				G2OEnabled: "true",
+				G2OKey:     "generated-key",
+				G2ONonce:   "generated-nonce",
+			})
+		}))
+		ec := newTestClient(t, pr)
+
+		d := schema.TestResourceDataRaw(t, advancedSchema, map[string]interface{}{
+			"name":         "my-app",
+			"description":  "",
+			"host":         "",
+			"auth_enabled": "false",
+			"advanced_settings": map[string]interface{}{
+				"edge_authentication_enabled": "true",
+				"g2o_enabled":                 "true",
+			},
+		})
+
+		err := ConfigureAdvancedSettings(context.Background(), "app-42", d, ec, true)
+		require.NoError(t, err)
+		assert.Equal(t, 3, putCount, "expected 3 PUTs: edge_auth=false, edge_auth=true, g2o keys")
+		assert.Equal(t, 1, g2oCount, "expected 1 G2O POST call")
+		assert.Equal(t, []string{"PUT", "PUT", "G2O", "PUT"}, callOrder, "G2O must happen after edge auth dance")
+	})
+
+	t.Run("isCreate_true_g2o_without_edge_auth_does_g2o_after_first_PUT", func(t *testing.T) {
+		putCount = 0
+		var g2oCount int
+		var callOrder []string
+		pr := newPathRouter(t)
+		pr.Handle("GET", "/crux/v1/mgmt-pop/apps/app-42", jsonHandler(http.StatusOK, appGetResp))
+		pr.Handle("PUT", "/crux/v1/mgmt-pop/apps/app-42", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			putCount++
+			callOrder = append(callOrder, "PUT")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"name": "my-app"})
+		}))
+		pr.Handle("POST", "/crux/v1/mgmt-pop/apps/app-42/g2o", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			g2oCount++
+			callOrder = append(callOrder, "G2O")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(G2OResponse{
+				G2OEnabled: "true",
+				G2OKey:     "generated-key",
+				G2ONonce:   "generated-nonce",
+			})
+		}))
+		ec := newTestClient(t, pr)
+
+		d := schema.TestResourceDataRaw(t, advancedSchema, map[string]interface{}{
+			"name":         "my-app",
+			"description":  "",
+			"host":         "",
+			"auth_enabled": "false",
+			"advanced_settings": map[string]interface{}{
+				"g2o_enabled": "true",
+			},
+		})
+
+		err := ConfigureAdvancedSettings(context.Background(), "app-42", d, ec, true)
+		require.NoError(t, err)
+		assert.Equal(t, 2, putCount, "expected 2 PUTs: initial + g2o keys")
+		assert.Equal(t, 1, g2oCount, "expected 1 G2O POST call")
+		assert.Equal(t, []string{"PUT", "G2O", "PUT"}, callOrder, "G2O after initial PUT, then final PUT with keys")
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/eaaprovider/app_read_helpers.go
+++ b/pkg/eaaprovider/app_read_helpers.go
@@ -186,17 +186,6 @@ func derefStr(p *string) string {
 	return *p
 }
 
-// serverComputedAdvancedSettingsKeys are keys the API auto-populates. They are used
-// only by the DiffSuppressFunc to prevent perpetual diffs when present in state but
-// absent from config (e.g. after an import or refresh-only).
-var serverComputedAdvancedSettingsKeys = map[string]bool{
-	"g2o_key":                    true,
-	"g2o_nonce":                  true,
-	"edge_cookie_key":            true,
-	"sla_object_url":             true,
-	"edge_transport_property_id": true,
-}
-
 // mapAdvancedSettingsFromResponse writes advanced_settings back into Terraform state.
 // All keys behave the same: on import/refresh-only (no prior state) every non-empty
 // API value is surfaced; on normal reads only keys already tracked in state are
@@ -416,6 +405,12 @@ func mapAdvancedSettingsFromResponse(d *schema.ResourceData, appResp *client.App
 		maps.Copy(result, existingState)
 		for k, v := range full {
 			if existingKeys[k] {
+				result[k] = v
+			}
+		}
+		// Always surface server-computed keys so users can reference them in outputs.
+		for k := range client.ServerComputedAdvancedSettingsKeys {
+			if v := full[k]; v != "" {
 				result[k] = v
 			}
 		}

--- a/pkg/eaaprovider/resource_eaa_application.go
+++ b/pkg/eaaprovider/resource_eaa_application.go
@@ -53,7 +53,7 @@ func suppressServerComputedAdvSettingsKey(k, old, newStr string, _ *schema.Resou
 		return false
 	}
 	key := parts[1]
-	if serverComputedAdvancedSettingsKeys[key] && newStr == "" {
+	if client.ServerComputedAdvancedSettingsKeys[key] && newStr == "" {
 		return true
 	}
 	// API returns null for session_sticky after update when originally set to "false"
@@ -64,6 +64,72 @@ func suppressServerComputedAdvSettingsKey(k, old, newStr string, _ *schema.Resou
 		return jsonSemanticEqual(old, newStr)
 	}
 	return false
+}
+
+// warnServerComputedKeys returns diagnostic warnings for any server-computed
+// advanced_settings keys that the user explicitly set in their config.
+// Uses GetRawConfig to read only user-written config, not state-merged values.
+func warnServerComputedKeys(d *schema.ResourceData) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	configKeys := configAdvancedSettingsKeys(d)
+	if len(configKeys) == 0 {
+		return diags
+	}
+	for k, s := range configKeys {
+		if !client.ServerComputedAdvancedSettingsKeys[k] {
+			continue
+		}
+		if s != "" {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("advanced_settings key %q is server-computed and will be ignored", k),
+				Detail:   fmt.Sprintf("The key %q in advanced_settings is auto-populated by the API. Your value %q will be ignored. Remove it from your configuration to suppress this warning.", k, s),
+			})
+		}
+	}
+	return diags
+}
+
+// configAdvancedSettingsKeys returns the advanced_settings keys from the user's
+// raw config (what they wrote in .tf). Falls back to d.GetOk when raw config is
+// unavailable (e.g. unit tests using TestResourceDataRaw).
+func configAdvancedSettingsKeys(d *schema.ResourceData) map[string]string {
+	rawConfig := d.GetRawConfig()
+	if !rawConfig.IsNull() {
+		advVal := rawConfig.GetAttr("advanced_settings")
+		if advVal.IsNull() || !advVal.IsKnown() {
+			return nil
+		}
+		vm := advVal.AsValueMap()
+		if len(vm) == 0 {
+			return nil
+		}
+		result := make(map[string]string, len(vm))
+		for k, v := range vm {
+			if v.IsNull() || !v.IsKnown() {
+				continue
+			}
+			result[k] = v.AsString()
+		}
+		return result
+	}
+	// Fallback for unit tests where GetRawConfig is not populated.
+	raw, ok := d.GetOk("advanced_settings")
+	if !ok {
+		return nil
+	}
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		if s, ok := v.(string); ok {
+			result[k] = s
+		}
+	}
+	return result
 }
 
 // jsonSemanticEqual returns true when a and b represent the same JSON value,
@@ -985,6 +1051,7 @@ func resourceEaaApplicationCreateTwoPhase(ctx context.Context, d *schema.Resourc
 		return logging.DiagFromErr(err, tags, "failed to get client")
 	}
 	var warningDiags diag.Diagnostics
+	warningDiags = append(warningDiags, warnServerComputedKeys(d)...)
 
 	var appUUIDURL string
 	var phase2Steps []func() error
@@ -1034,7 +1101,7 @@ func resourceEaaApplicationCreateTwoPhase(ctx context.Context, d *schema.Resourc
 		},
 		func() error {
 			logging.Debug(ctx, "phase 2: configuring advanced settings", tags)
-			return client.ConfigureAdvancedSettings(ctx, appUUIDURL, d, eaaclient)
+			return client.ConfigureAdvancedSettings(ctx, appUUIDURL, d, eaaclient, true)
 		},
 		func() error {
 			logging.Debug(ctx, "phase 2: deploying application", tags)
@@ -1136,6 +1203,7 @@ func resourceEaaApplicationUpdate(ctx context.Context, d *schema.ResourceData, m
 		return logging.DiagFromErr(err, tags, "failed to get client")
 	}
 	var warningDiags diag.Diagnostics
+	warningDiags = append(warningDiags, warnServerComputedKeys(d)...)
 
 	// Advanced settings validation is now handled at plan time via CustomizeDiff
 
@@ -1362,6 +1430,17 @@ func resourceEaaApplicationUpdate(ctx context.Context, d *schema.ResourceData, m
 				}
 			}
 		}
+	}
+
+	// Handle G2O before the final PUT — G2O generates keys that must be included in the update.
+	if appUpdateReq.AdvancedSettings.G2OEnabled == client.STR_TRUE {
+		logging.Debug(ctx, "g2o_enabled=true: calling UpdateG2O in UPDATE flow", tags)
+		g2oResp, g2oErr := appUpdateReq.UpdateG2O(ctx, eaaclient)
+		if g2oErr != nil {
+			return append(warningDiags, logging.DiagFromErr(g2oErr, tags, "g2o request failed")...)
+		}
+		appUpdateReq.AdvancedSettings.G2OKey = &g2oResp.G2OKey
+		appUpdateReq.AdvancedSettings.G2ONonce = &g2oResp.G2ONonce
 	}
 
 	// Now perform the PUT call to update advanced settings AFTER IDP assignment is complete

--- a/pkg/eaaprovider/resource_eaa_application_test.go
+++ b/pkg/eaaprovider/resource_eaa_application_test.go
@@ -14,6 +14,7 @@ import (
 
 	"git.source.akamai.com/terraform-provider-eaa/pkg/client"
 	"git.source.akamai.com/terraform-provider-eaa/pkg/testsupport"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
@@ -879,6 +880,74 @@ func TestSuppressServerComputedAdvSettingsKey(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			result := suppressServerComputedAdvSettingsKey(tc.key, tc.oldVal, tc.newVal, nil)
 			assert.Equal(t, tc.suppress, result)
+		})
+	}
+}
+
+func TestWarnServerComputedKeys(t *testing.T) {
+	advSchema := map[string]*schema.Schema{
+		"advanced_settings": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+	}
+
+	tests := map[string]struct {
+		values      map[string]interface{}
+		wantSummary string
+		wantCount   int
+	}{
+		"no_advanced_settings": {
+			values:    map[string]interface{}{},
+			wantCount: 0,
+		},
+		"only_user_keys": {
+			values: map[string]interface{}{
+				"advanced_settings": map[string]interface{}{
+					"acceleration": "true",
+				},
+			},
+			wantCount: 0,
+		},
+		"one_computed_key": {
+			values: map[string]interface{}{
+				"advanced_settings": map[string]interface{}{
+					"g2o_key": "user-set-value",
+				},
+			},
+			wantCount:   1,
+			wantSummary: `advanced_settings key "g2o_key" is server-computed and will be ignored`,
+		},
+		"multiple_computed_keys": {
+			values: map[string]interface{}{
+				"advanced_settings": map[string]interface{}{
+					"g2o_key":         "val1",
+					"edge_cookie_key": "val2",
+					"acceleration":    "true",
+				},
+			},
+			wantCount: 2,
+		},
+		"computed_key_empty_no_warning": {
+			values: map[string]interface{}{
+				"advanced_settings": map[string]interface{}{
+					"g2o_key": "",
+				},
+			},
+			wantCount: 0,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, advSchema, tt.values)
+			diags := warnServerComputedKeys(d)
+			assert.Len(t, diags, tt.wantCount)
+			if tt.wantCount > 0 && tt.wantSummary != "" {
+				assert.Equal(t, tt.wantSummary, diags[0].Summary)
+				assert.Equal(t, diag.Warning, diags[0].Severity)
+			}
 		})
 	}
 }


### PR DESCRIPTION
- server computed fields (`g2o_key`, `g2o_nonce`, `edge_cookie_key`, `sla_object_url`, `edge_transport_property_id`) are now ignored, and raise a warning when user tries to set.
- on edge_authentication_enabled=True create we now do 2 step update
- fix g2o "signature does not match" error 