### PR TITLE
fix: model registration token agents as objects, not strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module git.source.akamai.com/terraform-provider-eaa
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/akamai/AkamaiOPEN-edgegrid-golang/v6 v6.0.0

--- a/pkg/client/registrationtoken.go
+++ b/pkg/client/registrationtoken.go
@@ -26,20 +26,37 @@ func FormatExpiresAt(raw string) (string, error) {
 	return t.UTC().Format(time.RFC3339), nil
 }
 
+// RegistrationTokenAgent represents a connector assigned to a registration token.
+type RegistrationTokenAgent struct {
+	UUIDURL   string `json:"uuid_url"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at,omitempty"`
+	Status    int    `json:"status"`
+}
+
 // RegistrationToken represents a registration token for a connector pool
 type RegistrationToken struct {
-	UUIDURL             string   `json:"uuid_url,omitempty"`
-	Name                string   `json:"name"`
-	ConnectorPool       string   `json:"connector_pool"`
-	ExpiresAt           string   `json:"expires_at"`
-	ImageURL            string   `json:"image_url,omitempty"`
-	Token               string   `json:"token,omitempty"`
-	TokenSuffix         string   `json:"token_suffix,omitempty"`
-	ModifiedAt          string   `json:"modified_at,omitempty"`
-	Agents              []string `json:"agents,omitempty"`
-	MaxUse              int      `json:"max_use"`
-	UsedCount           int      `json:"used_count,omitempty"`
-	GenerateEmbeddedImg bool     `json:"generate_embedded_img,omitempty"`
+	UUIDURL             string                   `json:"uuid_url,omitempty"`
+	Name                string                   `json:"name"`
+	ConnectorPool       string                   `json:"connector_pool"`
+	ExpiresAt           string                   `json:"expires_at"`
+	ImageURL            string                   `json:"image_url,omitempty"`
+	Token               string                   `json:"token,omitempty"`
+	TokenSuffix         string                   `json:"token_suffix,omitempty"`
+	ModifiedAt          string                   `json:"modified_at,omitempty"`
+	Agents              []RegistrationTokenAgent `json:"agents,omitempty"`
+	MaxUse              int                      `json:"max_use"`
+	UsedCount           int                      `json:"used_count,omitempty"`
+	GenerateEmbeddedImg bool                     `json:"generate_embedded_img,omitempty"`
+}
+
+// AgentNames returns the names of the connectors assigned to the token.
+func (r *RegistrationToken) AgentNames() []string {
+	names := make([]string, len(r.Agents))
+	for i, agent := range r.Agents {
+		names[i] = agent.Name
+	}
+	return names
 }
 
 // MetaResponse represents the meta information in API responses

--- a/pkg/client/registrationtoken_test.go
+++ b/pkg/client/registrationtoken_test.go
@@ -2,11 +2,13 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormatExpiresAt(t *testing.T) {
@@ -116,6 +118,31 @@ func TestRegistrationTokenWriteRequest_Validate(t *testing.T) {
 			requireErrIs(t, err, tt.wantErr, nil)
 		})
 	}
+}
+
+func TestRegistrationToken_Agents(t *testing.T) {
+	body := `{
+		"name": "tok",
+		"agents": [
+			{"uuid_url": "vLLqK77yT_Sx6Wa_vwnyjw", "name": "connector-a", "status": 1, "created_at": "2026-06-25T08:19:13.279315Z"},
+			{"uuid_url": "otherUUID", "name": "connector-b", "status": 1, "created_at": "2026-06-25T08:19:13.279315Z"}
+		]
+	}`
+
+	var token RegistrationToken
+	require.NoError(t, json.Unmarshal([]byte(body), &token))
+
+	assert.Equal(t, []RegistrationTokenAgent{
+		{UUIDURL: "vLLqK77yT_Sx6Wa_vwnyjw", Name: "connector-a", Status: 1, CreatedAt: "2026-06-25T08:19:13.279315Z"},
+		{UUIDURL: "otherUUID", Name: "connector-b", Status: 1, CreatedAt: "2026-06-25T08:19:13.279315Z"},
+	}, token.Agents)
+	assert.Equal(t, []string{"connector-a", "connector-b"}, token.AgentNames())
+}
+
+func TestRegistrationToken_AgentNames_Empty(t *testing.T) {
+	var token RegistrationToken
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"tok","agents":[]}`), &token))
+	assert.Equal(t, []string{}, token.AgentNames())
 }
 
 func TestGetRegistrationTokens(t *testing.T) {

--- a/pkg/eaaprovider/resource_eaa_connector_pool.go
+++ b/pkg/eaaprovider/resource_eaa_connector_pool.go
@@ -420,7 +420,7 @@ func resourceEaaConnectorPoolRead(ctx context.Context, d *schema.ResourceData, m
 				"name":                  token.Name,
 				"max_use":               token.MaxUse,
 				"connector_pool":        token.ConnectorPool,
-				"agents":                token.Agents,
+				"agents":                token.AgentNames(),
 				"expires_at":            formattedExpiresAt,
 				"image_url":             token.ImageURL,
 				"token":                 token.Token,


### PR DESCRIPTION
https://github.com/akamai/terraform-eaa/pull/76#issue-4890804997