### PR TITLE
BWVONE-50686: paginate GetCertificates so uploaded cert lookups find …

### DIFF
--- a/pkg/client/certificates.go
+++ b/pkg/client/certificates.go
@@ -117,30 +117,66 @@ type CertificateExpandedResponse struct {
 
 type CertsResponse struct {
 	Objects []CertObject `json:"objects"`
+	Meta    Meta         `json:"meta,omitempty"`
 }
 
+// GetCertificates fetches all certificates from /certificates/thin, paginating
+// until the server signals no more pages. The server applies a default page
+// size (limit=0 is treated as "use server default"), so a single request only
+// returns the first page — callers that name-match over the result must see
+// every certificate, or lookups like DoesUploadedCertExist silently return
+// "not found" for certs beyond page 1.
 func GetCertificates(ctx context.Context, ec *EaaClient) ([]CertObject, error) {
-	apiURL := fmt.Sprintf("%s://%s/%s/thin", URL_SCHEME, ec.Host, CERTIFICATES_URL)
-	certsResponse := CertsResponse{}
+	tags := []logging.Tag{logging.TagAPI, logging.TagCert, logging.TagRead}
 
-	getResp, err := ec.SendAPIRequest(ctx, apiURL, "GET", nil, &certsResponse, false)
-	if err != nil {
-		return nil, err
-	}
-	if getResp.StatusCode < http.StatusOK || getResp.StatusCode >= http.StatusMultipleChoices {
-		tags := []logging.Tag{logging.TagAPI, logging.TagCert, logging.TagRead}
-		desc := FormatErrorDescription(getResp)
-		return nil, logging.Errorf(tags, "certificates get failed: %s", desc)
-	}
+	var allCerts []CertObject
+	offset := 0
+	var apiLimit int
 
-	var certs []CertObject
-	for _, cert := range certsResponse.Objects {
-		if cert.Name == "" || cert.UUIDURL == "" {
-			continue
+	for {
+		var apiURL string
+		if offset == 0 {
+			apiURL = fmt.Sprintf("%s://%s/%s/thin", URL_SCHEME, ec.Host, CERTIFICATES_URL)
+		} else {
+			apiURL = fmt.Sprintf("%s://%s/%s/thin?offset=%d", URL_SCHEME, ec.Host, CERTIFICATES_URL, offset)
 		}
-		certs = append(certs, cert)
+
+		certsResponse := CertsResponse{}
+		getResp, err := ec.SendAPIRequest(ctx, apiURL, "GET", nil, &certsResponse, false)
+		if err != nil {
+			return nil, err
+		}
+		if getResp.StatusCode < http.StatusOK || getResp.StatusCode >= http.StatusMultipleChoices {
+			desc := FormatErrorDescription(getResp)
+			return nil, logging.Errorf(tags, "certificates get failed: %s", desc)
+		}
+
+		for _, cert := range certsResponse.Objects {
+			if cert.Name == "" || cert.UUIDURL == "" {
+				continue
+			}
+			allCerts = append(allCerts, cert)
+		}
+
+		if offset == 0 {
+			apiLimit = certsResponse.Meta.Limit
+		}
+
+		if certsResponse.Meta.Next == nil {
+			break
+		}
+		if certsResponse.Meta.TotalCount > 0 && len(allCerts) >= certsResponse.Meta.TotalCount {
+			break
+		}
+		if apiLimit > 0 && len(certsResponse.Objects) < apiLimit {
+			break
+		}
+		if apiLimit <= 0 {
+			break
+		}
+		offset += apiLimit
 	}
-	return certs, nil
+	return allCerts, nil
 }
 
 func DoesSelfSignedCertExistForHost(ctx context.Context, ec *EaaClient, host string) (*CertObject, error) {

--- a/pkg/client/certificates_test.go
+++ b/pkg/client/certificates_test.go
@@ -2,9 +2,11 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
+	"git.source.akamai.com/terraform-provider-eaa/pkg/testsupport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,6 +45,57 @@ func TestGetCertificates(t *testing.T) {
 			assert.Len(t, certs, tt.wantCount)
 		})
 	}
+}
+
+// TestGetCertificatesPagination proves GetCertificates walks past the first
+// page. Regression test for BWVONE-50686: a cert beyond page 1 was invisible
+// to DoesUploadedCertExist, so app create with cert_type="uploaded" failed
+// with "uploaded certificate for host 'X' not found".
+func TestGetCertificatesPagination(t *testing.T) {
+	page1 := make([]CertObject, 0, 25)
+	for i := 0; i < 25; i++ {
+		page1 = append(page1, CertObject{
+			Name:     fmt.Sprintf("cert-page1-%d", i),
+			UUIDURL:  fmt.Sprintf("uuid-p1-%d", i),
+			CertType: CERT_TYPE_APP,
+		})
+	}
+	nextURL := "next-page"
+	page2 := []CertObject{
+		{Name: "app-cert-from-vault-kv", UUIDURL: "uuid-p2-0", CertType: CERT_TYPE_APP},
+		{Name: "cert-page2-1", UUIDURL: "uuid-p2-1", CertType: CERT_TYPE_APP},
+	}
+
+	var requestCount int
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		offset := r.URL.Query().Get("offset")
+		switch offset {
+		case "", "0":
+			testsupport.WriteJSONResponse(w, http.StatusOK, CertsResponse{
+				Objects: page1,
+				Meta:    Meta{Next: &nextURL, Limit: 25, TotalCount: 27},
+			})
+		case "25":
+			testsupport.WriteJSONResponse(w, http.StatusOK, CertsResponse{
+				Objects: page2,
+				Meta:    Meta{Limit: 25, TotalCount: 27},
+			})
+		default:
+			t.Fatalf("unexpected offset: %q", offset)
+		}
+	}
+
+	ec := newTestClient(t, http.HandlerFunc(handler))
+	certs, err := GetCertificates(context.Background(), ec)
+	require.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "expected pagination to make two requests")
+	assert.Len(t, certs, 27, "expected certs from both pages")
+
+	cert, err := DoesUploadedCertExist(context.Background(), ec, "app-cert-from-vault-kv")
+	require.NoError(t, err, "cert on page 2 must be findable after pagination")
+	require.NotNil(t, cert)
+	assert.Equal(t, "uuid-p2-0", cert.UUIDURL)
 }
 
 func TestDoesSelfSignedCertExistForHost(t *testing.T) {


### PR DESCRIPTION
…certs beyond page 1

The /certificates/thin endpoint applies a server-default page size, so a single request only returned the first page. DoesUploadedCertExist did a name match over that partial list, causing app create with cert_type="uploaded" to fail with "uploaded certificate for host 'X' not found" whenever the target cert lived on page 2+.

- Walk pages via offset until Meta.Next is nil (with total-count and short-page safeguards).
- Add TestGetCertificatesPagination regression test that serves two pages and verifies a page-2 cert is discoverable.